### PR TITLE
ci: increase golangci-lint-action timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         with:
           version: v1.50.1
+          args: --timeout 5m
   yaml-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It seems like golangci-lint needs more time when no cache is present. This PR increases the timeout (as suggested by the logged error) to 5 minutes.