### PR TITLE
test(e2e): increase timeout in vulnerability-overflow test

### DIFF
--- a/test/e2e-config/kuttl-test.yaml
+++ b/test/e2e-config/kuttl-test.yaml
@@ -6,5 +6,5 @@ metadata:
 testDirs:
   - test/e2e/scenario
   - test/e2e/workload-scan
-timeout: 120
+timeout: 240
 reportFormat: xml

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   digest: 'sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af'
   name: docker.io/kennship/http-echo
-  minSeverity: MEDIUM
+  minSeverity: LOW
 status:
   vulnerabilitySummary:
     severityCount: {}

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 60
+timeout: 120
 ---
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   digest: 'sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af'
   name: docker.io/kennship/http-echo
-  minSeverity: LOW
+  minSeverity: MEDIUM
 status:
   vulnerabilitySummary:
     severityCount: {}

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -1,4 +1,8 @@
 ---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:


### PR DESCRIPTION
Hopefully, this will make the e2e tests less fragile. The default timeout is 30 seconds, ref. https://kuttl.dev/docs/testing/reference.html#testassert

~~Also updating the asserted `minSeverity`, which appears to have changed.~~