### PR TITLE
test(e2e): increase timeout in vulnerability-overflow test, take two

### DIFF
--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -1,8 +1,4 @@
 ---
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
Give the vulnerability-overflow test step a bit more head room. Closes #19 