### PR TITLE
docs: add CIS CRD docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ A user can influence the image scanning process by adding annotations to pods.
 The set of annotations is currently limited, but more might be added in the
 future:
 
-| Pod annotation key                         | Default value | Description                                                                                                         |
-|--------------------------------------------|:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| `image-scanner.statnett.no/ignore-unfixed` | "false"       | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
+| Pod annotation key                         | Default value | Description                                                                                                           |
+|--------------------------------------------|:--------------|:----------------------------------------------------------------------------------------------------------------------|
+| `image-scanner.statnett.no/ignore-unfixed` | `"false"`     | If set to `"true"`, the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
 
 ### Supported features
 

--- a/README.md
+++ b/README.md
@@ -249,5 +249,5 @@ package "Image Scanner Operator" {
 
 Licensed under the [MIT License](LICENSE).
 
-[CIS-CRD]: https://doc.crds.dev/github.com/statnett/image-scanner-operator/stas.statnett.no/ContainerImageScan/v1alpha1@v0.0.0
+[CIS-CRD]: https://doc.crds.dev/github.com/statnett/image-scanner-operator/stas.statnett.no/ContainerImageScan/v1alpha1
 [CIS-example]: config/samples/stas_v1alpha1_containerimagescan.yaml

--- a/README.md
+++ b/README.md
@@ -60,7 +60,27 @@ software. Some key features of this operator are:
 
 ### Custom resources
 
-// TODO: Add a summary of key `ContainerImageScan` (CIS) characteristics
+The Image Scanner operator does currently define a single user-facing Custom
+Resource Definition (CRD), [ContainerImageScan][CIS-CRD] (CIS), that represents the
+Kubernetes API for runtime image scanning of workload container images.
+See [stas_v1alpha1_containerimagescan.yaml][CIS-example] for a (simplified)
+example of a CIS resource.
+
+The CIS resource `.spec` specifies the container image to scan and some
+additional workload metadata, and the image scan result is added/updated
+in `.status` by the `ContainerImageScan` controller.
+
+CIS resources should not be edited by a standard users, as the `Workload`
+controller will create CIS'es from scheduled pods. And the standard Kubernetes
+garbage collector should delete obsolete resources when owning pods are gone.
+
+A user can influence the image scanning process by adding annotations to pods.
+The set of annotations is currently limited, but more might be added in the
+future:
+
+| Pod annotation                           | Default (not present) | Description                                                                                                         |
+|------------------------------------------|:----------------------|:--------------------------------------------------------------------------------------------------------------------|
+| image-scanner.statnett.no/ignore-unfixed | "false"               | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
 
 ### Supported features
 
@@ -228,3 +248,6 @@ package "Image Scanner Operator" {
 ## License
 
 Licensed under the [MIT License](LICENSE).
+
+[CIS-CRD]: https://doc.crds.dev/github.com/statnett/image-scanner-operator/stas.statnett.no/ContainerImageScan/v1alpha1@v0.0.0
+[CIS-example]: config/samples/stas_v1alpha1_containerimagescan.yaml

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ A user can influence the image scanning process by adding annotations to pods.
 The set of annotations is currently limited, but more might be added in the
 future:
 
-| Pod annotation                             | Default (not present) | Description                                                                                                         |
-|--------------------------------------------|:----------------------|:--------------------------------------------------------------------------------------------------------------------|
-| `image-scanner.statnett.no/ignore-unfixed` | "false"               | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
+| Pod annotation key                         | Default value | Description                                                                                                         |
+|--------------------------------------------|:--------------|:--------------------------------------------------------------------------------------------------------------------|
+| `image-scanner.statnett.no/ignore-unfixed` | "false"       | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
 
 ### Supported features
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ future:
 
 | Pod annotation key                         | Default value | Description                                                                                                           |
 |--------------------------------------------|:--------------|:----------------------------------------------------------------------------------------------------------------------|
-| `image-scanner.statnett.no/ignore-unfixed` | `"false"`     | If set to `"true"`, the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
+| `image-scanner.statnett.no/ignore-unfixed` | `"false"`     | If set to `"true"`, the Image Scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
 
 ### Supported features
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ A user can influence the image scanning process by adding annotations to pods.
 The set of annotations is currently limited, but more might be added in the
 future:
 
-| Pod annotation                           | Default (not present) | Description                                                                                                         |
-|------------------------------------------|:----------------------|:--------------------------------------------------------------------------------------------------------------------|
-| image-scanner.statnett.no/ignore-unfixed | "false"               | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
+| Pod annotation                             | Default (not present) | Description                                                                                                         |
+|--------------------------------------------|:----------------------|:--------------------------------------------------------------------------------------------------------------------|
+| `image-scanner.statnett.no/ignore-unfixed` | "false"               | If set to "true", the image-scanner will ignore any detected vulnerability that can't be fix by updating package(s) |
 
 ### Supported features
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ software. Some key features of this operator are:
 
 ### Custom resources
 
-The Image Scanner operator does currently define a single user-facing Custom
+The Image Scanner operator currently defines a single user-facing Custom
 Resource Definition (CRD), [ContainerImageScan][CIS-CRD] (CIS), that represents the
 Kubernetes API for runtime image scanning of workload container images.
 See [stas_v1alpha1_containerimagescan.yaml][CIS-example] for a (simplified)
@@ -70,8 +70,8 @@ The CIS resource `.spec` specifies the container image to scan and some
 additional workload metadata, and the image scan result is added/updated
 in `.status` by the `ContainerImageScan` controller.
 
-CIS resources should not be edited by a standard users, as the `Workload`
-controller will create CIS'es from scheduled pods. And the standard Kubernetes
+CIS resources should not be edited by standard users, as the `Workload`
+controller will create CIS'es from running pods. And the standard Kubernetes
 garbage collector should delete obsolete resources when owning pods are gone.
 
 A user can influence the image scanning process by adding annotations to pods.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ in `.status` by the `ContainerImageScan` controller.
 
 CIS resources should not be edited by standard users, as the `Workload`
 controller will create CIS'es from running pods. And the standard Kubernetes
-garbage collector should delete obsolete resources when owning pods are gone.
+garbage collector deletes the obsolete CIS resources when the owning pods are gone.
 
 A user can influence the image scanning process by adding annotations to pods.
 The set of annotations is currently limited, but more might be added in the

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ additional workload metadata, and the image scan result is added/updated
 in `.status` by the `ContainerImageScan` controller.
 
 CIS resources should not be edited by standard users, as the `Workload`
-controller will create CIS'es from running pods. And the standard Kubernetes
-garbage collector deletes the obsolete CIS resources when the owning pods are gone.
+controller will create CIS resources from running pods. And the standard
+Kubernetes garbage collector deletes the obsolete CIS resources when the
+owning pods are gone.
 
 A user can influence the image scanning process by adding annotations to pods.
 The set of annotations is currently limited, but more might be added in the

--- a/config/samples/stas_v1alpha1_containerimagescan.yaml
+++ b/config/samples/stas_v1alpha1_containerimagescan.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: nginx
 spec:
   digest: 'sha256:0fd172200e9ef7d3187cf526b24567027992ffce8a34cc9d5ac0d18deb974d33'
-  name: artifactory.statnett.no/dockerhub-docker-remote/nginxinc/nginx-unprivileged
+  name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app
     group: ''

--- a/config/samples/stas_v1alpha1_containerimagescan.yaml
+++ b/config/samples/stas_v1alpha1_containerimagescan.yaml
@@ -1,12 +1,273 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
+  name: pod-nginx-app-afd44
+  ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: nginx
+      uid: 4b759b6e-cce1-4327-9110-7f81bc1cd37d
   labels:
-    app.kubernetes.io/name: containerimagescan
-    app.kubernetes.io/instance: containerimagescan-sample
-    app.kubernetes.io/part-of: image-scanner-operator
-    app.kuberentes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: image-scanner-operator
-  name: containerimagescan-sample
+    app.kubernetes.io/name: nginx
 spec:
-# TODO(user): Add fields here
+  digest: 'sha256:0fd172200e9ef7d3187cf526b24567027992ffce8a34cc9d5ac0d18deb974d33'
+  name: artifactory.statnett.no/dockerhub-docker-remote/nginxinc/nginx-unprivileged
+  workload:
+    containerName: app
+    group: ''
+    kind: Pod
+    name: nginx
+status:
+  lastScanJobName: pod-nginx-app-afd44hs7rw
+  lastScanTime: '2023-01-10T10:24:53Z'
+  lastSuccessfulScanTime: '2023-01-10T10:24:53Z'
+  observedGeneration: 1
+  vulnerabilities:
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32207'
+      severity: CRITICAL
+      title: 'curl: Unpreserved file permissions'
+      vulnerabilityID: CVE-2022-32207
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32221'
+      severity: CRITICAL
+      title: 'curl: POST following PUT confusion'
+      vulnerabilityID: CVE-2022-32221
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-42915'
+      severity: CRITICAL
+      title: 'curl: HTTP proxy double-free'
+      vulnerabilityID: CVE-2022-42915
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32207'
+      severity: CRITICAL
+      title: 'curl: Unpreserved file permissions'
+      vulnerabilityID: CVE-2022-32207
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32221'
+      severity: CRITICAL
+      title: 'curl: POST following PUT confusion'
+      vulnerabilityID: CVE-2022-32221
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-42915'
+      severity: CRITICAL
+      title: 'curl: HTTP proxy double-free'
+      vulnerabilityID: CVE-2022-42915
+    - fixedVersion: 1.2.12-r2
+      installedVersion: 1.2.12-r0
+      pkgName: zlib
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-37434'
+      severity: CRITICAL
+      title: >-
+        zlib: heap-based buffer over-read and overflow in inflate() in inflate.c
+        via a large gzip header extra field
+      vulnerabilityID: CVE-2022-37434
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27780'
+      severity: HIGH
+      title: 'curl: percent-encoded path separator in URL host'
+      vulnerabilityID: CVE-2022-27780
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27781'
+      severity: HIGH
+      title: 'curl: CERTINFO never-ending busy-loop'
+      vulnerabilityID: CVE-2022-27781
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27782'
+      severity: HIGH
+      title: 'curl: TLS and SSH connection too eager reuse'
+      vulnerabilityID: CVE-2022-27782
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-42916'
+      severity: HIGH
+      title: 'curl: HSTS bypass via IDN'
+      vulnerabilityID: CVE-2022-42916
+    - fixedVersion: 7.80.0-r5
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-43551'
+      severity: HIGH
+      title: 'curl: HSTS bypass via IDN'
+      vulnerabilityID: CVE-2022-43551
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27780'
+      severity: HIGH
+      title: 'curl: percent-encoded path separator in URL host'
+      vulnerabilityID: CVE-2022-27780
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27781'
+      severity: HIGH
+      title: 'curl: CERTINFO never-ending busy-loop'
+      vulnerabilityID: CVE-2022-27781
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-27782'
+      severity: HIGH
+      title: 'curl: TLS and SSH connection too eager reuse'
+      vulnerabilityID: CVE-2022-27782
+    - fixedVersion: 7.80.0-r4
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-42916'
+      severity: HIGH
+      title: 'curl: HSTS bypass via IDN'
+      vulnerabilityID: CVE-2022-42916
+    - fixedVersion: 7.80.0-r5
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-43551'
+      severity: HIGH
+      title: 'curl: HSTS bypass via IDN'
+      vulnerabilityID: CVE-2022-43551
+    - fixedVersion: 2.9.14-r1
+      installedVersion: 2.9.14-r0
+      pkgName: libxml2
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-2309'
+      severity: HIGH
+      title: 'lxml: NULL Pointer Dereference in lxml'
+      vulnerabilityID: CVE-2022-2309
+    - fixedVersion: 2.9.14-r2
+      installedVersion: 2.9.14-r0
+      pkgName: libxml2
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-40303'
+      severity: HIGH
+      title: 'libxml2: integer overflows with XML_PARSE_HUGE'
+      vulnerabilityID: CVE-2022-40303
+    - fixedVersion: 2.9.14-r2
+      installedVersion: 2.9.14-r0
+      pkgName: libxml2
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-40304'
+      severity: HIGH
+      title: 'libxml2: dict corruption caused by entity reference cycles'
+      vulnerabilityID: CVE-2022-40304
+    - fixedVersion: 6.3_p20211120-r1
+      installedVersion: 6.3_p20211120-r0
+      pkgName: ncurses-libs
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-29458'
+      severity: HIGH
+      title: 'ncurses: segfaulting OOB read'
+      vulnerabilityID: CVE-2022-29458
+    - fixedVersion: 6.3_p20211120-r1
+      installedVersion: 6.3_p20211120-r0
+      pkgName: ncurses-terminfo-base
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-29458'
+      severity: HIGH
+      title: 'ncurses: segfaulting OOB read'
+      vulnerabilityID: CVE-2022-29458
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32205'
+      severity: MEDIUM
+      title: 'curl: Set-Cookie denial of service'
+      vulnerabilityID: CVE-2022-32205
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32206'
+      severity: MEDIUM
+      title: 'curl: HTTP compression denial of service'
+      vulnerabilityID: CVE-2022-32206
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32208'
+      severity: MEDIUM
+      title: 'curl: FTP-KRB bad message verification'
+      vulnerabilityID: CVE-2022-32208
+    - fixedVersion: 7.80.0-r5
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-43552'
+      severity: MEDIUM
+      title: 'curl: HTTP Proxy deny use-after-free'
+      vulnerabilityID: CVE-2022-43552
+    - fixedVersion: 1.1.1q-r0
+      installedVersion: 1.1.1n-r0
+      pkgName: libcrypto1.1
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-2097'
+      severity: MEDIUM
+      title: 'openssl: AES OCB fails to encrypt some bytes'
+      vulnerabilityID: CVE-2022-2097
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32205'
+      severity: MEDIUM
+      title: 'curl: Set-Cookie denial of service'
+      vulnerabilityID: CVE-2022-32205
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32206'
+      severity: MEDIUM
+      title: 'curl: HTTP compression denial of service'
+      vulnerabilityID: CVE-2022-32206
+    - fixedVersion: 7.80.0-r2
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-32208'
+      severity: MEDIUM
+      title: 'curl: FTP-KRB bad message verification'
+      vulnerabilityID: CVE-2022-32208
+    - fixedVersion: 7.80.0-r5
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-43552'
+      severity: MEDIUM
+      title: 'curl: HTTP Proxy deny use-after-free'
+      vulnerabilityID: CVE-2022-43552
+    - fixedVersion: 1.1.1q-r0
+      installedVersion: 1.1.1n-r0
+      pkgName: libssl1.1
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-2097'
+      severity: MEDIUM
+      title: 'openssl: AES OCB fails to encrypt some bytes'
+      vulnerabilityID: CVE-2022-2097
+    - fixedVersion: 7.80.0-r3
+      installedVersion: 7.80.0-r1
+      pkgName: curl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-35252'
+      severity: LOW
+      title: 'curl: control code in cookie denial of service'
+      vulnerabilityID: CVE-2022-35252
+    - fixedVersion: 7.80.0-r3
+      installedVersion: 7.80.0-r1
+      pkgName: libcurl
+      primaryURL: 'https://avd.aquasec.com/nvd/cve-2022-35252'
+      severity: LOW
+      title: 'curl: control code in cookie denial of service'
+      vulnerabilityID: CVE-2022-35252
+  vulnerabilitySummary:
+    fixedCount: 34
+    severityCount:
+      CRITICAL: 7
+      HIGH: 15
+      LOW: 2
+      MEDIUM: 10
+      UNKNOWN: 0


### PR DESCRIPTION
This PR attempt to document the CIS CRD (using https://doc.crds.dev/), including user-facing annotations that can be added to pods to influence the image scanning.