### PR TITLE
ci(docker): build and push images for pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
       - main
     tags:
       - v*
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
 permissions:
   contents: read
 env:
@@ -22,7 +26,6 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
@@ -43,6 +46,7 @@ jobs:
             # disabled if major zero
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=ref,event=branch
+            type=ref,event=pr
       - uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           context: .


### PR DESCRIPTION
This adds building and pushing images to pull requests. It must run on the `pull_request_target` to get permission to push to the container registry.

If this works, I hope it could avoid the image import in the CI e2e-test, and hopefully mend https://github.com/statnett/image-scanner-operator/issues/21.

Also, we should also add container repository pruning in a follow-up PR. But let's first see if it works.