### PR TITLE
ci(release): make release-please workflow update image tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,4 +27,6 @@ jobs:
               { "type": "fix", "section": "Bug Fixes" },
               { "type": "build", "scope": "deps", "section": "Dependency Updates" }
             ]
-          release-type: go
+          release-type: simple
+          extra-files: |
+            config/manager/kustomization.yaml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,3 +30,4 @@ jobs:
           release-type: simple
           extra-files: |
             kustomization.yaml
+            README.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,4 +29,4 @@ jobs:
             ]
           release-type: simple
           extra-files: |
-            config/manager/kustomization.yaml
+            kustomization.yaml

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ base. Your initial kustomization.yaml could be as simple as:
 
 ```yaml
 resources:
-  - https://github.com/statnett/image-scanner-operator?ref=vMAJOR.MINOR.PATCH
+  - https://github.com/statnett/image-scanner-operator?ref=v0.0.0 # x-release-please-version
 ```
 
 If you have multiple clusters, you should create one

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ base. Your initial kustomization.yaml could be as simple as:
 
 ```yaml
 resources:
-  - https://github.com/statnett/image-scanner-operator//config/default?ref=vMAJOR.MINOR.PATCH
+  - https://github.com/statnett/image-scanner-operator?ref=vMAJOR.MINOR.PATCH
 ```
 
 If you have multiple clusters, you should create one

--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ the Image Scanner default kustomization as a
 [remote directory](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md#remote-directories)
 base. Your initial kustomization.yaml could be as simple as:
 
+<!-- x-release-please-start-version -->
 ```yaml
 resources:
-  - https://github.com/statnett/image-scanner-operator?ref=v0.0.0 # x-release-please-version
+  - https://github.com/statnett/image-scanner-operator?ref=v0.0.0
 ```
+<!-- x-release-please-end -->
 
 If you have multiple clusters, you should create one
 [variant](https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#variant)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -19,5 +19,5 @@ configMapGenerator:
     name: config
 images:
   - name: controller
-    newName: image-scanner/controller
-    newTag: latest
+    newName: ghcr.io/statnett/image-scanner-operator
+    newTag: 0.0.0 # x-release-please-version

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -19,5 +19,5 @@ configMapGenerator:
     name: config
 images:
   - name: controller
-    newName: ghcr.io/statnett/image-scanner-operator
-    newTag: 0.0.0 # x-release-please-version
+    newName: image-scanner/controller
+    newTag: latest

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config/default
+images:
+  - name: image-scanner/controller
+    newName: ghcr.io/statnett/image-scanner-operator
+    newTag: 0.0.0 # x-release-please-version


### PR DESCRIPTION
This will make the release-please workflow update the operator image tag in the release PR. This has been tested in https://github.com/erikgb/operator-ci-test. See https://github.com/erikgb/operator-ci-test/pull/12 for an example on how this might look like.

~~Running the e2e-tests locally will now modify a file that should not be committed to Git, but I have an idea on how to fix that. Probably by introducing a tailored e2e kustomize overlay.~~ Update: Added a new customization file in root folder. This will also allow for simpler install of the operator. See installation of prometheus-operator as an example:
https://github.com/statnett/image-scanner-operator/blob/280b3a10f4611587d181cba7c0e500a7cd4477c4/config/deploy-dependencies/prometheus-operator/kustomization.yaml#L5
Which refers to https://github.com/prometheus-operator/prometheus-operator/blob/v0.60.1/kustomization.yaml