### PR TITLE
test(e2e): use image in GHCR for PR in e2e-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,7 @@ jobs:
           make deploy-dependencies deploy
         env:
           # Image tag format differs for pull requests and branch pushes
-          IMG: >-
-            ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
+          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - run: |
           make deploy-dependencies deploy
         env:
-          IMG: ghcr.io/statnett/image-scanner-operator:pr-${{ github.event.issue.number }}
+          IMG: ghcr.io/statnett/image-scanner-operator:pr-${{ github.event.number }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
       - run: |
           make deploy-dependencies deploy
         env:
-          IMG: ghcr.io/statnett/image-scanner-operator:pr-${{ github.event.number }}
+          # Image tag format differs for pull requests and branch pushes
+          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: make test
-  build-image:
+  e2e-test:
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -91,34 +91,6 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
-      - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
-      - uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
-        with:
-          context: .
-          push: false
-          tags: image-scanner/controller:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/controller-image.tar
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: controller-image
-          path: /tmp/controller-image.tar
-  e2e-test:
-    needs: build-image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: controller-image
-          path: /tmp
       - uses: AbsaOSS/k3d-action@597f8436a25d6d2e8e46a5047ed986a833a6674c # v2.4.0
         with:
           cluster-name: image-scanner
@@ -128,8 +100,9 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import --cluster image-scanner /tmp/controller-image.tar
           make deploy-dependencies deploy
+        env:
+          IMG: ghcr.io/statnett/image-scanner-operator:pr-${{ github.event.issue.number }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
           make deploy-dependencies deploy
         env:
           # Image tag format differs for pull requests and branch pushes
-          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
+          IMG: >-
+            ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - run: |
           make deploy-dependencies deploy
         env:
-          # Image tag format differs for pull requests and branch pushes
+          # Poor man's ternary expression; Image tag format differs for pull requests and branch pushes
           IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,5 +7,5 @@ rules:
     require-starting-space: false
   document-start: disable
   line-length:
-    max: 130
+    max: 140
     allow-non-breakable-inline-mappings: true

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,5 +7,5 @@ rules:
     require-starting-space: false
   document-start: disable
   line-length:
-    max: 120
+    max: 130
     allow-non-breakable-inline-mappings: true


### PR DESCRIPTION
This PR uses the image pushed to GHCR for pull requests (https://github.com/statnett/image-scanner-operator/pull/30) in the e2e-tests. Thus avoiding the image import into the e2e cluster.

Closes https://github.com/statnett/image-scanner-operator/issues/21
