### PR TITLE
ci(fix): use correct image tag on branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           make deploy-dependencies deploy
         env:
           # Poor man's ternary expression; Image tag format differs for pull requests and branch pushes
-          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref }}
+          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref_name }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl


### PR DESCRIPTION
It seems like we use the wrong property in the [github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to obtain the short branch name.

See https://github.com/statnett/image-scanner-operator/actions/runs/3900778458/jobs/6661883753