### PR TITLE
build(deps): bump aquasecurity/trivy from 0.35.0 to 0.36.1

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
   - literals:
       - CIS_METRICS_LABELS=app.kubernetes.io/name
       - SCAN_INTERVAL=12h
-      - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.35.0
+      - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.36.1
       - TRIVY_SERVER=http://trivy.image-scanner.svc.cluster.local
       - SCAN_JOB_NAMESPACE=image-scanner-jobs
       - SCAN_JOB_SERVICE_ACCOUNT=image-scanner

--- a/config/trivy-server/stateful_set.yaml
+++ b/config/trivy-server/stateful_set.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: ghcr.io/aquasecurity/trivy:0.35.0
+          image: ghcr.io/aquasecurity/trivy:0.36.1
           args:
             - server
           envFrom:


### PR DESCRIPTION
This bumps trivy to the latest release.

Could we make Dependabot (or Renovate) fix these tasks?