### PR TITLE
fix: don't use generateName when creating jobs

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -3,7 +3,6 @@ package v1alpha1
 const (
 	LabelK8sAppName                  = "app.kubernetes.io/name"
 	LabelK8SAppManagedBy             = "app.kubernetes.io/managed-by"
-	LabelStatnettControllerHash      = "controller.statnett.no/hash"
 	LabelStatnettControllerNamespace = "controller.statnett.no/namespace"
 	LabelStatnettControllerUID       = "controller.statnett.no/uid"
 

--- a/controllers/containerimagescan_controller_test.go
+++ b/controllers/containerimagescan_controller_test.go
@@ -64,7 +64,6 @@ var _ = Describe("ContainerImageScan controller", func() {
 	normalizeUntestableScanJobFields := func(job *batchv1.Job) *batchv1.Job {
 		job.APIVersion = "batch/v1"
 		job.Kind = "Job"
-		job.Name = ""
 		job.UID = ""
 		job.ResourceVersion = ""
 		job.CreationTimestamp = metav1.Time{}

--- a/controllers/testdata/scan-job/expected-scan-job.yaml
+++ b/controllers/testdata/scan-job/expected-scan-job.yaml
@@ -4,15 +4,14 @@ kind: Job
 metadata:
   annotations:
     batch.kubernetes.io/job-tracking: ""
-  generateName: echo-6bdfc76c56-8ae43
   generation: 1
   labels:
     app.kubernetes.io/managed-by: image-scanner
     app.kubernetes.io/name: trivy
-    controller.statnett.no/hash: 81f104762422c0137dee1c58e2c4d454
     controller.statnett.no/namespace: replica-set
     controller.statnett.no/uid: <CIS-UID>
   namespace: image-scanner-jobs
+  name: echo-6bdfc76c56-8ae43-8731b
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 3

--- a/controllers/workload_controller.go
+++ b/controllers/workload_controller.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -31,7 +32,7 @@ import (
 
 const (
 	ImageShortSHALength     = 5
-	KubernetesNameMaxLength = 253
+	KubernetesNameMaxLength = validation.DNS1123SubdomainMaxLength
 )
 
 var noEventsEventHandler = handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {


### PR DESCRIPTION
The main purpose of this PR is to address the fragile tests we have been seeing in #19 and #27. After the investigation performed by @padlar, it seems like the underlying cause might be duplicate jobs. So I took a closer look, and using `generateName` in a controller seems like a bad idea - since the name will be a random one and not deterministic. 

So this PR replaces use of `generateName` with a deterministic name, composed by CIS name, spec and namespace. But since a Kubernetes job has a `name` max length of 63 characters, we need to do this "smart".

Finally I found some constants in an api-machinery package for these max length values.

The e2e-tests seems to work again after this PR, so we should re-enable them in a follow-up PR. Ref. https://github.com/statnett/image-scanner-operator/pull/63

We should probably try to revert https://github.com/statnett/image-scanner-operator/pull/41 and lower the e2e test timeout in follow-up PRs if we see that this fix works.