### PR TITLE
ci(e2e-test): replace k3d with k3s to bootstrap cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,9 @@ jobs:
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: debianmaster/actions-k3s@b9cf3f599fd118699a3c8a0d18a2f2bda6cf4ce4 # v1.0.5
+        id: k3s
         with:
-          version: 'v1.26.0+k3s2'
+          version: 'v1.21.2-k3s1'
       - run: |
           kubectl cluster-info
           kubectl version --output=yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,9 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: AbsaOSS/k3d-action@597f8436a25d6d2e8e46a5047ed986a833a6674c # v2.4.0
+      - uses: debianmaster/actions-k3s@b9cf3f599fd118699a3c8a0d18a2f2bda6cf4ce4 # v1.0.5
         with:
-          cluster-name: image-scanner
-          args: >-
-            --config=test/e2e-config/k3d-config.yml
+          version: v1.26.0+k3s2
       - run: |
           kubectl cluster-info
           kubectl version --output=yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: debianmaster/actions-k3s@b9cf3f599fd118699a3c8a0d18a2f2bda6cf4ce4 # v1.0.5
         with:
-          version: v1.26.0+k3s2
+          version: 'v1.26.0+k3s2'
       - run: |
           kubectl cluster-info
           kubectl version --output=yaml


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
