### PR TITLE
chore: improved clear cache

### DIFF
--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -1,7 +1,7 @@
 ---
 name: Clear cache
 on:
-  workflow_dispatch:
+  pull_request:
 permissions:
   actions: write
 jobs:
@@ -9,20 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear cache
-        uses: actions/github-script@v6
-        with:
-          script: |
-            console.log("About to clear")
-            const caches = await github.rest.actions.getActionsCacheList({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
-            for (const cache of caches.data.actions_caches) {
-              console.log(cache)
-              github.rest.actions.deleteActionsCacheById({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                cache_id: cache.id,
-              })
-            }
-            console.log("Clear completed")
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete --confirm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Clear cache
         run: |
           gh extension install actions/gh-actions-cache
-          
+
           echo "Fetching list of cache key"
           ## The maximum GH fetch limit is 100
           cacheKeysForPR=$(gh actions-cache list -L 100 | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR

--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -8,6 +8,11 @@ jobs:
   clear-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Clear cache
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -1,7 +1,7 @@
 ---
 name: Clear cache
 on:
-  pull_request:
+  workflow_dispatch:
 permissions:
   actions: write
 jobs:
@@ -18,6 +18,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           
           echo "Fetching list of cache key"
+          ## The maximum GH fetch limit is 100
           cacheKeysForPR=$(gh actions-cache list -L 100 | cut -f 1 )
 
           ## Setting this to not fail the workflow while deleting cache keys. 

--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -18,7 +18,7 @@ jobs:
           gh extension install actions/gh-actions-cache
           
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list | cut -f 1 )
+          cacheKeysForPR=$(gh actions-cache list -L 100 | cut -f 1 )
 
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e

--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -11,6 +11,17 @@ jobs:
       - name: Clear cache
         run: |
           gh extension install actions/gh-actions-cache
-          gh actions-cache delete --confirm
+          
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey --confirm
+          done
+          echo "Done"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current "clear cache" only nukes 10 caches each time. This is an improvement that deletes 100 caches for each run.

Based on https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries