### PR TITLE
fix(cli): should print help when requested

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,8 +51,8 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr, probeAddr                string
-		enableLeaderElection, enableProfiling bool
+		metricsAddr, probeAddr                               string
+		helpRequested, enableLeaderElection, enableProfiling bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -76,8 +76,13 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.BoolP("help", "h", false, "Display help text and exit")
+	pflag.BoolVarP(&helpRequested, "help", "h", false, "print out usage and a summary of options")
 	pflag.Parse()
+
+	if helpRequested {
+		pflag.Usage()
+		os.Exit(0)
+	}
 
 	err := viper.BindPFlags(pflag.CommandLine)
 	if err != nil {


### PR DESCRIPTION
In our docs we describe how to list operator settings:

![image](https://user-images.githubusercontent.com/1142578/212417403-f08f1daa-c134-4225-a05a-3ce755321a94.png)

But this does not work after https://github.com/statnett/image-scanner-operator/pull/29. The problem seems to be that after we add a help-flag, we need to implement the behavior.