### PR TITLE
ci(e2e-test): disable e2e testing in CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
           cache: true
       - run: make test
   e2e-test:
+    # FIXME: The e2e-tests are currently always failing because what appears like CPU limitations
+    if: false
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It seems like the e2e-tests are always failing since last Thursday afternoon. I have been trying to find the root cause, but no luck so far. It seems like the tests somehow need more CPU than what's available on the hosted GitHub runners:

```
logger.go:42: 17:46:24 | vulnerability-overflow/0-create | 4m32s       Warning   FailedScheduling   pod/deployment-prometheus-operator-prometheus-operator-65d485x5clrs   0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.
```

But this used to work before - with some flakiness, ref. https://github.com/statnett/image-scanner-operator/issues/19

This will allow us to move forward but introduces more risk. Fixing the e2e test issue should be a priority!