### PR TITLE
fix: add GenerationChangedPredicate to CIS controller

### DIFF
--- a/controllers/containerimagescan_controller.go
+++ b/controllers/containerimagescan_controller.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/controller"
@@ -63,7 +64,11 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 // SetupWithManager sets up the controller with the Manager.
 func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&stasv1alpha1.ContainerImageScan{}, builder.WithPredicates(ignoreDeletionPredicate())).
+		For(&stasv1alpha1.ContainerImageScan{},
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+				ignoreDeletionPredicate(),
+			)).
 		Complete(r)
 }
 


### PR DESCRIPTION
This PR adds a missing GenerationChangedPredicate to CIS controller setup, and will avoid some unnecessary reconciles that could potentially create duplicate jobs.

Extracted from https://github.com/statnett/image-scanner-operator/pull/48