### PR TITLE
revert: "ci(e2e-test): disable e2e testing in CI for now (#63)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
           cache: true
       - run: make test
   e2e-test:
-    # FIXME: The e2e-tests are currently always failing because what appears like CPU limitations
-    if: false
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This reverts commit fb99134adb27c176d5fc064c95253e3218bfce6a.

https://github.com/statnett/image-scanner-operator/pull/48 seems to fix the e2e-test issues.