### PR TITLE
revert: "test(go): disable caching Job objects (#41)"

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -89,10 +89,8 @@ var _ = BeforeSuite(func() {
 		Expect(err).To(Succeed())
 	}
 
-	// FIXME: temporarily disable cache to see if the tests pass in Github
-	uncachedObjects := []client.Object{&batchv1.Job{}}
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		NewClient: cluster.ClientBuilderWithOptions(cluster.ClientOptions{CacheUnstructured: true, UncachedObjects: uncachedObjects}),
+		NewClient: cluster.ClientBuilderWithOptions(cluster.ClientOptions{CacheUnstructured: true}),
 		Scheme:    scheme.Scheme,
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This reverts commit 74dc3df160fee0a6fbd1e33144b1615a783bf9a9.
