### PR TITLE
test(e2e): try out kuttl collectors

### DIFF
--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -14,6 +14,8 @@ status:
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:
+  - type: command
+    command: df -h
   - type: events
     namespace: image-scanner-jobs
   - type: pod

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -22,3 +22,5 @@ collectors:
   - type: pod
     namespace: image-scanner
     selector: control-plane=image-scanner
+  - type: command
+    command: kubectl describe node

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -10,3 +10,15 @@ spec:
 status:
   vulnerabilitySummary:
     severityCount: {}
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: events
+    namespace: image-scanner-jobs
+  - type: pod
+    namespace: image-scanner
+    pod: trivy-0
+  - type: pod
+    namespace: image-scanner
+    selector: control-plane=image-scanner


### PR DESCRIPTION
This PR enables kuttl collectors for the e2e-test that seems most fragile. Ref. https://github.com/statnett/image-scanner-operator/issues/19