### PR TITLE
ci: fix correct digest reference to AbsaOSS/k3d-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,8 @@ jobs:
         uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: AbsaOSS/k3d-action@597f8436a25d6d2e8e46a5047ed986a833a6674c # v2.4.0
+      - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: image-scanner
           args: >-


### PR DESCRIPTION
https://github.com/statnett/image-scanner-operator/pull/69 reveals that we had a bug in the digest/version reference to AbsaOSS/k3d-action. This PR fixes that.