### PR TITLE
test: bump K8s version to 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= "image-scanner/controller:latest"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
+ENVTEST_K8S_VERSION = 1.26.0
 # Namespace to install operator into
 K8S_NAMESPACE ?= image-scanner
 
@@ -170,7 +170,7 @@ GOIMPORTS ?= $(LOCALBIN)/goimports
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.10.0
+CONTROLLER_TOOLS_VERSION ?= v0.11.1
 GOIMPORTS_VERSION ?= v0.3.0
 
 .PHONY: kustomize

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: containerimagescans.stas.statnett.no
 spec:

--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -3,4 +3,4 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: image-scanner
-image: docker.io/rancher/k3s:v1.25.4-k3s1
+image: docker.io/rancher/k3s:v1.26.0-k3s2


### PR DESCRIPTION
This bumps controller-tools, controller-gen and k3s versions to K8s 1.26 compliant versions.