### PR TITLE
feat(cli): make regexp for excluded namespace configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"log"
 
+	"github.com/spf13/pflag"
+
 	"github.com/statnett/image-scanner-operator/internal/config"
 	"github.com/statnett/image-scanner-operator/internal/operator"
 )
@@ -13,6 +15,13 @@ func main() {
 	cfg.Zap.Development = true
 
 	opr := operator.Operator{}
+	opr.BindFlags(&cfg, flag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	opr.UnmarshalConfig(&cfg)
+	opr.ValidateConfig(cfg)
+	opr.Start(cfg)
 	if err := opr.BindConfig(&cfg, flag.CommandLine); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,14 +15,13 @@ func main() {
 	cfg.Zap.Development = true
 
 	opr := operator.Operator{}
-	opr.BindFlags(&cfg, flag.CommandLine)
+	if err := opr.BindFlags(&cfg, flag.CommandLine); err != nil {
+		log.Fatal(err)
+	}
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	opr.UnmarshalConfig(&cfg)
-	opr.ValidateConfig(cfg)
-	opr.Start(cfg)
-	if err := opr.BindConfig(&cfg, flag.CommandLine); err != nil {
+	if err := opr.UnmarshalConfig(&cfg); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 	if err := opr.BindFlags(&cfg, flag.CommandLine); err != nil {
 		log.Fatal(err)
 	}
+
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
       - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.36.1
       - SCAN_JOB_NAMESPACE=image-scanner-jobs
       - SCAN_JOB_SERVICE_ACCOUNT=image-scanner
+      - SCAN_NAMESPACE_EXCLUDE_REGEXP=^kuttl-.*
       - SCAN_WORKLOAD_RESOURCES=deployments.apps,replicasets.apps,statefulsets.apps,daemonsets.apps,cronjobs.batch,jobs.batch,replicationcontrollers
       - ZAP_ENCODER=json
       - ZAP_LOG_LEVEL=info

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,7 +11,6 @@ configMapGenerator:
       - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.36.1
       - SCAN_JOB_NAMESPACE=image-scanner-jobs
       - SCAN_JOB_SERVICE_ACCOUNT=image-scanner
-      - SCAN_NAMESPACE_EXCLUDE_REGEXP=^kuttl-.*
       - SCAN_WORKLOAD_RESOURCES=deployments.apps,replicasets.apps,statefulsets.apps,daemonsets.apps,cronjobs.batch,jobs.batch,replicationcontrollers
       - ZAP_ENCODER=json
       - ZAP_LOG_LEVEL=info

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/distribution/distribution v2.8.1+incompatible
 	github.com/go-logr/logr v1.2.3
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.7.1
 	github.com/onsi/gomega v1.26.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -57,7 +58,6 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/statnett/controller-runtime-viper/pkg/zap"
@@ -9,14 +10,15 @@ import (
 )
 
 type Config struct {
-	MetricsLabels         []string      `mapstructure:"cis-metrics-labels"`
-	ScanInterval          time.Duration `mapstructure:"scan-interval"`
-	ScanJobNamespace      string        `mapstructure:"scan-job-namespace"`
-	ScanJobServiceAccount string        `mapstructure:"scan-job-service-account"`
-	ScanNamespaces        []string      `mapstructure:"namespaces"`
-	ScanWorkloadResources []string      `mapstructure:"scan-workload-resources"`
-	TrivyImage            string        `mapstructure:"trivy-image"`
-	Zap                   zap.Options   `mapstructure:"-"`
+	MetricsLabels              []string       `mapstructure:"cis-metrics-labels"`
+	ScanInterval               time.Duration  `mapstructure:"scan-interval"`
+	ScanJobNamespace           string         `mapstructure:"scan-job-namespace"`
+	ScanJobServiceAccount      string         `mapstructure:"scan-job-service-account"`
+	ScanNamespaces             []string       `mapstructure:"namespaces"`
+	ScanNamespaceExcludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
+	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
+	TrivyImage                 string         `mapstructure:"trivy-image"`
+	Zap                        zap.Options    `mapstructure:"-"`
 }
 
 func (c Config) TimeUntilNextScan(cis *stasv1alpha1.ContainerImageScan) time.Duration {

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -66,6 +66,7 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&stasv1alpha1.ContainerImageScan{},
 			builder.WithPredicates(

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -71,6 +71,7 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if r.ScanNamespaceExcludeRegexp != nil {
 		bldr.WithEventFilter(predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+
 	return bldr.Complete(r)
 }
 

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -62,13 +62,16 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&stasv1alpha1.ContainerImageScan{},
 			builder.WithPredicates(
 				predicate.GenerationChangedPredicate{},
 				ignoreDeletionPredicate(),
-			)).
-		Complete(r)
+			))
+	if r.ScanNamespaceExcludeRegexp != nil {
+		bldr.WithEventFilter(predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
+	}
+	return bldr.Complete(r)
 }
 
 func (r *ContainerImageScanReconciler) reconcile(ctx context.Context, cis *stasv1alpha1.ContainerImageScan) error {

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -14,11 +14,11 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-var systemNamespaceRegex = regexp.MustCompile("^(kube-|openshift-).*")
-
-var systemNamespace = predicate.NewPredicateFuncs(func(object client.Object) bool {
-	return systemNamespaceRegex.MatchString(object.GetNamespace())
-})
+func namespaceMatchRegexp(re *regexp.Regexp) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return re.MatchString(object.GetNamespace())
+	})
+}
 
 func podContainerStatusImagesChanged() predicate.Predicate {
 	return predicate.Funcs{

--- a/internal/operator/decode_hooks.go
+++ b/internal/operator/decode_hooks.go
@@ -1,0 +1,26 @@
+package operator
+
+import (
+	"reflect"
+	"regexp"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// stringToRegexpHookFunc returns a DecodeHookFunc that converts strings to regexp.Regexp.
+func stringToRegexpHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+
+		if t != reflect.TypeOf(&regexp.Regexp{}) {
+			return data, nil
+		}
+
+		return regexp.Compile(data.(string))
+	}
+}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -75,9 +75,11 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	return nil
 }
 
-func (o Operator) UnmarshalConfig(cfg *config.Config) {
+func (o Operator) UnmarshalConfig(cfg *config.Config) error {
 	helpRequested := viper.GetBool("help")
 	if helpRequested {
 		pflag.Usage()

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -59,6 +59,7 @@ func (o Operator) BindConfig(cfg *config.Config, fs *flag.FlagSet) error {
 	flag.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
 	flag.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
 	flag.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
+	flag.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	flag.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	flag.Bool("help", false, "print out usage and a summary of options")
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/statnett/controller-runtime-viper/pkg/zap"
@@ -46,26 +47,24 @@ func init() {
 
 type Operator struct{}
 
-func (o Operator) BindConfig(cfg *config.Config, fs *flag.FlagSet) error {
-	flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.Bool("leader-elect", false,
+func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
+	fs.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	fs.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.Bool("leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.Bool("enable-profiling", false, "Enable profiling (pprof); available on metrics endpoint.")
-	flag.String("namespaces", "", "comma-separated list of namespaces to watch")
-	flag.String("cis-metrics-labels", "", "comma-separated list of labels in CIS resources to create metrics labels for")
-	flag.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
-	flag.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
-	flag.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
-	flag.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
-	flag.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
-	flag.String("trivy-image", "", "The image used for obtaining the trivy binary.")
-	flag.Bool("help", false, "print out usage and a summary of options")
+	fs.Bool("enable-profiling", false, "Enable profiling (pprof); available on metrics endpoint.")
+	fs.String("namespaces", "", "comma-separated list of namespaces to watch")
+	fs.String("cis-metrics-labels", "", "comma-separated list of labels in CIS resources to create metrics labels for")
+	fs.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
+	fs.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
+	fs.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
+	fs.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
+	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
+	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
+	fs.Bool("help", false, "print out usage and a summary of options")
 
 	cfg.Zap.BindFlags(fs)
-	pflag.CommandLine.AddGoFlagSet(fs)
-	pflag.Parse()
 
 	pfs := &pflag.FlagSet{}
 	pfs.AddGoFlagSet(fs)
@@ -76,14 +75,21 @@ func (o Operator) BindConfig(cfg *config.Config, fs *flag.FlagSet) error {
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+}
 
+func (o Operator) UnmarshalConfig(cfg *config.Config) {
 	helpRequested := viper.GetBool("help")
 	if helpRequested {
 		pflag.Usage()
 		os.Exit(0)
 	}
 
-	if err := viper.Unmarshal(cfg); err != nil {
+	hook := mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		stringToRegexpHookFunc(),
+	)
+	if err := viper.Unmarshal(cfg, viper.DecodeHook(hook)); err != nil {
 		return fmt.Errorf("unable to decode config into struct: %w", err)
 	}
 

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -1,0 +1,41 @@
+package operator
+
+import (
+	"flag"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/statnett/image-scanner-operator/internal/config"
+)
+
+var _ = Describe("Operator config from flags", func() {
+	var (
+		opr Operator = Operator{}
+		fs  *flag.FlagSet
+		cfg *config.Config
+	)
+
+	BeforeEach(func() {
+		fs = flag.NewFlagSet("read from env", flag.ExitOnError)
+		cfg = &config.Config{}
+		opr.BindFlags(cfg, fs)
+	})
+
+	Context("Using scan-namespace-exclude-regexp flag", func() {
+		It("Should have correct default", func() {
+			fs.Parse(nil)
+			opr.UnmarshalConfig(cfg)
+			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
+			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^(kube-|openshift-).*"))
+		})
+
+		It("Should be configurable", func() {
+			fs.Parse([]string{"--scan-namespace-exclude-regexp=^$"})
+			opr.UnmarshalConfig(cfg)
+			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
+			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^$"))
+		})
+	})
+
+})

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -19,13 +19,13 @@ var _ = Describe("Operator config from flags", func() {
 	BeforeEach(func() {
 		fs = flag.NewFlagSet("test", flag.ExitOnError)
 		cfg = &config.Config{}
-		opr.BindFlags(cfg, fs)
+		Expect(opr.BindFlags(cfg, fs)).To(Succeed())
 	})
 
 	Context("Using scan-namespace-exclude-regexp flag", func() {
 		It("Should have correct default", func() {
 			Expect(fs.Parse(nil)).To(Succeed())
-			opr.UnmarshalConfig(cfg)
+			Expect(opr.UnmarshalConfig(cfg)).To(Succeed())
 			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
 			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^(kube-|openshift-).*"))
 		})
@@ -33,9 +33,15 @@ var _ = Describe("Operator config from flags", func() {
 		It("Should be configurable", func() {
 			args := []string{"--scan-namespace-exclude-regexp=^$"}
 			Expect(fs.Parse(args)).To(Succeed())
-			opr.UnmarshalConfig(cfg)
+			Expect(opr.UnmarshalConfig(cfg)).To(Succeed())
 			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
 			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^$"))
+		})
+
+		It("Should error on invalid regexp", func() {
+			args := []string{"--scan-namespace-exclude-regexp=["}
+			Expect(fs.Parse(args)).To(Succeed())
+			Expect(opr.UnmarshalConfig(cfg)).To(MatchError(ContainSubstring("error parsing regexp")))
 		})
 	})
 

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -24,14 +24,15 @@ var _ = Describe("Operator config from flags", func() {
 
 	Context("Using scan-namespace-exclude-regexp flag", func() {
 		It("Should have correct default", func() {
-			fs.Parse(nil)
+			Expect(fs.Parse(nil)).To(Succeed())
 			opr.UnmarshalConfig(cfg)
 			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
 			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^(kube-|openshift-).*"))
 		})
 
 		It("Should be configurable", func() {
-			fs.Parse([]string{"--scan-namespace-exclude-regexp=^$"})
+			args := []string{"--scan-namespace-exclude-regexp=^$"}
+			Expect(fs.Parse(args)).To(Succeed())
 			opr.UnmarshalConfig(cfg)
 			Expect(cfg.ScanNamespaceExcludeRegexp).NotTo(BeNil())
 			Expect(cfg.ScanNamespaceExcludeRegexp.String()).To(Equal("^$"))

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Operator config from flags", func() {
 	)
 
 	BeforeEach(func() {
-		fs = flag.NewFlagSet("read from env", flag.ExitOnError)
+		fs = flag.NewFlagSet("test", flag.ExitOnError)
 		cfg = &config.Config{}
 		opr.BindFlags(cfg, fs)
 	})

--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -1,0 +1,13 @@
+package operator
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}


### PR DESCRIPTION
This PR makes the regexp for excluding namespaces from scanning, typically system namespaces, configurable. While this feature might be useful for some, the plan is to add an equivalent configurable property for namespaces to include. And this will allow us to avoid scanning anything other than the workload images under test in our e2e-tests.
