### PR TITLE
feat: add workload labels on the scan job

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -5,6 +5,9 @@ const (
 	LabelK8SAppManagedBy             = "app.kubernetes.io/managed-by"
 	LabelStatnettControllerNamespace = "controller.statnett.no/namespace"
 	LabelStatnettControllerUID       = "controller.statnett.no/uid"
+	LabelStatnettWorkloadKind        = "workload.statnett.no/kind"
+	LabelStatnettWorkloadName        = "workload.statnett.no/name"
+	LabelStatnettWorkloadNamespace   = "workload.statnett.no/namespace"
 
 	AppNameImageScanner = "image-scanner"
 	AppNameTrivy        = "trivy"

--- a/controllers/testdata/scan-job/cis.yaml
+++ b/controllers/testdata/scan-job/cis.yaml
@@ -7,3 +7,6 @@ metadata:
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged
+  workload:
+    kind: Pod
+    name: echo

--- a/controllers/testdata/scan-job/expected-scan-job.yaml
+++ b/controllers/testdata/scan-job/expected-scan-job.yaml
@@ -10,8 +10,11 @@ metadata:
     app.kubernetes.io/name: trivy
     controller.statnett.no/namespace: replica-set
     controller.statnett.no/uid: <CIS-UID>
+    workload.statnett.no/kind: Pod
+    workload.statnett.no/name: echo
+    workload.statnett.no/namespace: replica-set
   namespace: image-scanner-jobs
-  name: echo-6bdfc76c56-8ae43-b4cf9
+  name: echo-6bdfc76c56-8ae43-2693c
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 3

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -75,18 +75,18 @@ func (f *filesystemScanJobBuilder) ForCIS(cis *stasv1alpha1.ContainerImageScan) 
 		stasv1alpha1.LabelStatnettControllerNamespace: cis.Namespace,
 		stasv1alpha1.LabelStatnettControllerUID:       string(cis.UID),
 		stasv1alpha1.LabelStatnettWorkloadKind:        cis.Spec.Workload.Kind,
-		stasv1alpha1.LabelStatnettWorkloadName:        workloadLabelName(cis),
+		stasv1alpha1.LabelStatnettWorkloadName:        truncateString(cis.Spec.Workload.Name, KubernetesLabelValueMaxLength),
 		stasv1alpha1.LabelStatnettWorkloadNamespace:   cis.Namespace,
 	}
 
 	return job, nil
 }
 
-func workloadLabelName(cis *stasv1alpha1.ContainerImageScan) string {
-	if len(cis.Spec.Workload.Name) > KubernetesLabelValueMaxLength {
-		return cis.Spec.Workload.Name[0 : KubernetesLabelValueMaxLength-1]
+func truncateString(name string, length int) string {
+	if len(name) > length {
+		return name[0 : length-1]
 	} else {
-		return cis.Spec.Workload.Name
+		return name
 	}
 }
 

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -73,9 +73,9 @@ func (f *filesystemScanJobBuilder) ForCIS(cis *stasv1alpha1.ContainerImageScan) 
 		stasv1alpha1.LabelK8SAppManagedBy:             stasv1alpha1.AppNameImageScanner,
 		stasv1alpha1.LabelStatnettControllerNamespace: cis.Namespace,
 		stasv1alpha1.LabelStatnettControllerUID:       string(cis.UID),
-		stasv1alpha1.LabelStatnettWorkloadKind:        string(cis.Spec.Workload.Kind),
-		stasv1alpha1.LabelStatnettWorkloadName:        string(cis.Spec.Workload.Name),
-		stasv1alpha1.LabelStatnettWorkloadNamespace:   string(cis.Namespace),
+		stasv1alpha1.LabelStatnettWorkloadKind:        cis.Spec.Workload.Kind,
+		stasv1alpha1.LabelStatnettWorkloadName:        cis.Spec.Workload.Name,
+		stasv1alpha1.LabelStatnettWorkloadNamespace:   cis.Namespace,
 	}
 
 	return job, nil

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -73,6 +73,9 @@ func (f *filesystemScanJobBuilder) ForCIS(cis *stasv1alpha1.ContainerImageScan) 
 		stasv1alpha1.LabelK8SAppManagedBy:             stasv1alpha1.AppNameImageScanner,
 		stasv1alpha1.LabelStatnettControllerNamespace: cis.Namespace,
 		stasv1alpha1.LabelStatnettControllerUID:       string(cis.UID),
+		stasv1alpha1.LabelStatnettWorkloadKind:        string(cis.Spec.Workload.Kind),
+		stasv1alpha1.LabelStatnettWorkloadName:        string(cis.Spec.Workload.Name),
+		stasv1alpha1.LabelStatnettWorkloadNamespace:   string(cis.Namespace),
 	}
 
 	return job, nil

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -24,8 +24,5 @@ collectors:
   - type: pod
     namespace: image-scanner
     selector: control-plane=image-scanner
-  - type: pod
-    namespace: image-scanner-jobs
-    selector: workload.statnett.no/name=vuln-app
   - type: command
     command: kubectl describe node

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -24,5 +24,8 @@ collectors:
   - type: pod
     namespace: image-scanner
     selector: control-plane=image-scanner
+  - type: pod
+    namespace: image-scanner-jobs
+    selector: workload.statnett.no/name=vuln-app
   - type: command
     command: kubectl describe node


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
This adds extra labels to the scan Job with information about the workload that is being scanned. This will make it easier to debug the e2e-tests that are failing.