### PR TITLE
fix: add workload labels to the podTemplate in the scan Job

### DIFF
--- a/controllers/containerimagescan_controller_test.go
+++ b/controllers/containerimagescan_controller_test.go
@@ -82,6 +82,8 @@ var _ = Describe("ContainerImageScan controller", func() {
 				job.Spec.Template.Labels[k] = "<CONTROLLER-UID>"
 			case "job-name":
 				job.Spec.Template.Labels[k] = "<JOB-NAME>"
+			case stasv1alpha1.LabelStatnettControllerUID:
+				job.Spec.Template.Labels[k] = "<CIS-UID>"
 			}
 
 		}

--- a/controllers/testdata/scan-job/expected-scan-job.yaml
+++ b/controllers/testdata/scan-job/expected-scan-job.yaml
@@ -29,6 +29,11 @@ spec:
         app.kubernetes.io/name: trivy
         controller-uid: <CONTROLLER-UID>
         job-name: <JOB-NAME>
+        controller.statnett.no/namespace: replica-set
+        controller.statnett.no/uid: <CIS-UID>
+        workload.statnett.no/kind: Pod
+        workload.statnett.no/name: echo
+        workload.statnett.no/namespace: replica-set
     spec:
       affinity:
         nodeAffinity:

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -78,6 +78,7 @@ func (f *filesystemScanJobBuilder) ForCIS(cis *stasv1alpha1.ContainerImageScan) 
 		stasv1alpha1.LabelStatnettWorkloadName:        truncateString(cis.Spec.Workload.Name, KubernetesLabelValueMaxLength),
 		stasv1alpha1.LabelStatnettWorkloadNamespace:   cis.Namespace,
 	}
+	job.Spec.Template.Labels = job.Labels
 
 	return job, nil
 }
@@ -113,10 +114,6 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 		return nil, err
 	}
 
-	job.Spec.Template.Labels = map[string]string{
-		stasv1alpha1.LabelK8sAppName:      stasv1alpha1.AppNameTrivy,
-		stasv1alpha1.LabelK8SAppManagedBy: stasv1alpha1.AppNameImageScanner,
-	}
 	job.Spec.Template.Spec.InitContainers = []corev1.Container{f.initContainer()}
 	job.Spec.Template.Spec.Containers = []corev1.Container{container}
 	job.Spec.Template.Spec.Volumes = []corev1.Volume{


### PR DESCRIPTION
#80 only added labels to the scan Job, this PR also adds workload labels to the scan Pod.

Related to #19 