### PR TITLE
ci(e2e): reconfigure collectors for flaky e2e-test

### DIFF
--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -25,4 +25,3 @@ collectors:
   - type: pod
     namespace: image-scanner-jobs
     selector: workload.statnett.no/name=vuln-app
-    tail: -1

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -22,7 +22,6 @@ collectors:
   - type: pod
     namespace: image-scanner
     selector: control-plane=image-scanner
-    tail: -1
   - type: pod
     namespace: image-scanner-jobs
     selector: workload.statnett.no/name=vuln-app

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -14,8 +14,6 @@ status:
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:
-  - type: command
-    command: df -h
   - type: events
     namespace: image-scanner-jobs
   - type: pod
@@ -24,5 +22,8 @@ collectors:
   - type: pod
     namespace: image-scanner
     selector: control-plane=image-scanner
-  - type: command
-    command: kubectl describe node
+    tail: -1
+  - type: pod
+    namespace: image-scanner-jobs
+    selector: workload.statnett.no/name=vuln-app
+    tail: -1


### PR DESCRIPTION
This reconfigures the collectors for the flaky e2e-test, ref. https://github.com/statnett/image-scanner-operator/issues/19. Trying to get as much info as possible from assumed relevant stuff.