### PR TITLE
ci(perf): allow e2e-test to run parallel to test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           cache: true
       - run: make test
   e2e-test:
-    needs: test
+    needs: verify-generated
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Which should speed up the overall running checks time.

There is no "real" dependency from e2e-test to test. The e2e-tests require that the operator image is available, but there is no way to specify dependencies across workflows. It this becomes a problem, there are workarounds available.