### PR TITLE
ci(fix): use single quotes in schedule in prune ghcr workflow

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -2,7 +2,7 @@
 name: Delete obsolete container images
 on:
   schedule:
-    - cron: "0 0 1 * *"  # every day at midnight
+    - cron: '0 0 1 * *'  # every day at midnight
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Quote schedule cron expression, ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

Closes #97 