### PR TITLE
test(e2e): replace trivy server cache PVC with emptyDir

### DIFF
--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -23,8 +23,6 @@ patches:
         volumeClaimTemplates: []
         template:
           spec:
-            containers:
-              - name: server
             volumes:
               - name: data
                 emptyDir: {}

--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -3,12 +3,28 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../default
-# FIXME: Somehow sessionAffinity does not work when running e2e tests in some environments
 patches:
+  # FIXME: Somehow sessionAffinity does not work when running e2e tests in some environments
   # Disable trivy server sessionAffinity; not really needed when running a single replica
-  - target:
+  - patch: |-
+      apiVersion: v1
       kind: Service
-      name: trivy
-    patch: |-
-      - op: remove
-        path: /spec/sessionAffinity
+      metadata:
+        name: trivy
+      spec:
+        sessionAffinity: None
+  # Replace PVC with emptyDir for e2e-tests
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: trivy
+      spec:
+        volumeClaimTemplates: []
+        template:
+          spec:
+            containers:
+              - name: server
+            volumes:
+              - name: data
+                emptyDir: {}


### PR DESCRIPTION
To avoid persistent volume issues, and because we don't need it, this PR replaces the PVC requested by the trivy server StatefulSet with a simple emptyDir.

Also replacing the JSON patch for `sessionAffinity` with a strategic merge patch - to avoid mixing patch strategies.