### PR TITLE
ci(e2e): upload pod logs as artifact on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,13 @@ jobs:
       - run: |
           make e2e-test
 
-      - if: ${{ always() }}
-        # Copy files from volume to avoid permission denied
+      - if: ${{ failure() }}
+        # Copy files from volume and update permissions to avoid permission denied
         run: |
           sudo cp -r /tmp/pod-logs/ pod-logs/
           sudo chmod -R a+rw pod-logs/
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        if: ${{ always() }}
+        if: ${{ failure() }}
         with:
           name: pod-logs
           path: pod-logs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,13 @@ jobs:
           cache: enable
       - run: |
           make e2e-test
+
+      - if: ${{ always() }}
+        # Copy files from volume to avoid permission denied
+        run: |
+          sudo cp -r /tmp/pod-logs/ pod-logs/
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ always() }}
         with:
           name: pod-logs
-          path: /tmp/pod-logs/
+          path: pod-logs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - run: |
+          mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: image-scanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
           cache: enable
       - run: |
           make e2e-test
-
       - if: ${{ failure() }}
         # Copy files from volume and update permissions to avoid permission denied
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
           cache: enable
       - run: |
           make e2e-test
-      - if: ${{ always() }}
-        run: |
-          ls -al /tmp/pod-logs
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ always() }}
+        with:
+          name: pod-logs
+          path: /tmp/pod-logs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           cluster-name: image-scanner
           args: >-
             --config=test/e2e-config/k3d-config.yml
+            --volume=/tmp/pod-logs:/var/log/pods
       - run: |
           kubectl cluster-info
           kubectl version --output=yaml
@@ -122,3 +123,6 @@ jobs:
           cache: enable
       - run: |
           make e2e-test
+      - if: ${{ always() }}
+        run: |
+          ls -al /tmp/pod-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         # Copy files from volume to avoid permission denied
         run: |
           sudo cp -r /tmp/pod-logs/ pod-logs/
+          sudo chmod -R a+rw pod-logs/
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ always() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
       - if: ${{ failure() }}
         # Copy files from volume and update permissions to avoid permission denied
         run: |
+          kubectl get pods -n image-scanner-jobs -l workload.statnett.no/name=vuln-app -o yaml
           sudo cp -r /tmp/pod-logs/ pod-logs/
           sudo chmod -R a+rw pod-logs/
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
Do dig further into the flaky e2e-test, this PR will ensure that all pod logs are uploaded as GH artifacts on job failure.

Also outputting the vuln scan job pods YAML in case this fails - as this is the test we have be struggling with.