### PR TITLE
feat(admin)!: kustomizeable configmap for scan job default configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,6 @@ func main() {
 	flag.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
 	flag.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
 	flag.String("trivy-image", "", "The image used for obtaining the trivy binary.")
-	flag.String("trivy-server", "", "The server to use in Trivy client/server mode.")
 	flag.Bool("help", false, "print out usage and a summary of options")
 
 	opts := zap.Options{

--- a/config/image-scanner-jobs/kustomization.yaml
+++ b/config/image-scanner-jobs/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - namespace.yaml
   - resource_quota.yaml
   - service_account.yaml
+configMapGenerator:
+  - name: trivy
+    literals:
+      - OFFLINE_SCAN=true
+      - SERVER=http://trivy.image-scanner.svc.cluster.local
+      - TIMEOUT=30m
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,7 +9,6 @@ configMapGenerator:
       - CIS_METRICS_LABELS=app.kubernetes.io/name
       - SCAN_INTERVAL=12h
       - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.36.1
-      - TRIVY_SERVER=http://trivy.image-scanner.svc.cluster.local
       - SCAN_JOB_NAMESPACE=image-scanner-jobs
       - SCAN_JOB_SERVICE_ACCOUNT=image-scanner
       - SCAN_WORKLOAD_RESOURCES=deployments.apps,replicasets.apps,statefulsets.apps,daemonsets.apps,cronjobs.batch,jobs.batch,replicationcontrollers

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -104,7 +104,6 @@ var _ = BeforeSuite(func() {
 		ScanJobNamespace:      scanJobNamespace,
 		ScanJobServiceAccount: "image-scanner",
 		TrivyImage:            "aquasecurity/trivy",
-		TrivyServer:           "http://trivy.image-scanner.svc.cluster.local",
 	}
 
 	podReconciler := &PodReconciler{

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: image-scanner-jobs
   name: echo-6bdfc76c56-8ae43-b63f8
 spec:
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 3600 # 1 hour
   backoffLimit: 3
   completionMode: NonIndexed
   completions: 1
@@ -55,22 +55,20 @@ spec:
           env:
             - name: HOME
               value: /tmp
-            - name: TRIVY_OFFLINE_SCAN
-              value: "true"
             - name: TRIVY_SECURITY_CHECKS
               value: vuln
             - name: TRIVY_CACHE_DIR
               value: /tmp
-            - name: TRIVY_SERVER
-              value: http://trivy.image-scanner.svc.cluster.local
             - name: TRIVY_QUIET
               value: "true"
             - name: TRIVY_FORMAT
               value: template
             - name: TRIVY_TEMPLATE
               value: <REPORT-TEMPLATE>
-            - name: TRIVY_TIMEOUT
-              value: 1h0m0s
+          envFrom:
+            - prefix: TRIVY_
+              configMapRef:
+                name: trivy
           image: docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
           imagePullPolicy: IfNotPresent
           name: scan-image


### PR DESCRIPTION
Close #109 

BREAKING CHANGE: This moves the configuration of Trivy server from the operator configmap to the new configmap for scan jobs. Any admins overriding the default value will is required to update their configuration.