### PR TITLE
refactor: consistent organization of code in main

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,7 +80,8 @@ func main() {
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	if viper.GetBool("help") {
+	helpRequested := viper.GetBool("help")
+	if helpRequested {
 		pflag.Usage()
 		os.Exit(0)
 	}
@@ -100,13 +101,16 @@ func main() {
 	ctrl.SetLogger(logger)
 	klog.SetLogger(logger)
 
+	metricsAddr := viper.GetString("metrics-bind-address")
+	probeAddr := viper.GetString("health-probe-bind-address")
+	enableLeaderElection := viper.GetBool("leader-elect")
 	options := ctrl.Options{
 		NewClient:              cluster.ClientBuilderWithOptions(cluster.ClientOptions{CacheUnstructured: true}),
 		Scheme:                 scheme,
-		MetricsBindAddress:     viper.GetString("metrics-bind-address"),
+		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
-		HealthProbeBindAddress: viper.GetString("health-probe-bind-address"),
-		LeaderElection:         viper.GetBool("leader-elect"),
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "398aa7bc.statnett.no",
 	}
 
@@ -173,7 +177,8 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if viper.GetBool("enable-profiling") {
+	enableProfiling := viper.GetBool("enable-profiling")
+	if enableProfiling {
 		err = mgr.AddMetricsExtraHandler("/debug/pprof/", http.HandlerFunc(pprof.Index))
 		if err != nil {
 			setupLog.Error(err, "unable to attach pprof to webserver")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,17 +50,12 @@ func init() {
 }
 
 func main() {
-	var (
-		metricsAddr, probeAddr                string
-		enableLeaderElection, enableProfiling bool
-	)
-
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.Bool("leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&enableProfiling, "enable-profiling", false, "Enable profiling (pprof); available on metrics endpoint.")
+	flag.Bool("enable-profiling", false, "Enable profiling (pprof); available on metrics endpoint.")
 	flag.String(flagNamespaces, "", "comma-separated list of namespaces to watch")
 	flag.String(flagCISMetricsLabels, "", "comma-separated list of labels in CIS resources to create metrics labels for")
 	flag.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
@@ -110,10 +105,10 @@ func main() {
 	options := ctrl.Options{
 		NewClient:              cluster.ClientBuilderWithOptions(cluster.ClientOptions{CacheUnstructured: true}),
 		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
+		MetricsBindAddress:     viper.GetString("metrics-bind-address"),
 		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
+		HealthProbeBindAddress: viper.GetString("health-probe-bind-address"),
+		LeaderElection:         viper.GetBool("leader-elect"),
 		LeaderElectionID:       "398aa7bc.statnett.no",
 	}
 
@@ -185,7 +180,7 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if enableProfiling {
+	if viper.GetBool("enable-profiling") {
 		err = mgr.AddMetricsExtraHandler("/debug/pprof/", http.HandlerFunc(pprof.Index))
 		if err != nil {
 			setupLog.Error(err, "unable to attach pprof to webserver")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,9 +32,7 @@ import (
 )
 
 const (
-	ErrCreateCtrl        = "unable to create controller"
-	flagCISMetricsLabels = "cis-metrics-labels"
-	flagNamespaces       = "namespaces"
+	ErrCreateCtrl = "unable to create controller"
 )
 
 var (
@@ -56,8 +54,8 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Bool("enable-profiling", false, "Enable profiling (pprof); available on metrics endpoint.")
-	flag.String(flagNamespaces, "", "comma-separated list of namespaces to watch")
-	flag.String(flagCISMetricsLabels, "", "comma-separated list of labels in CIS resources to create metrics labels for")
+	flag.String("namespaces", "", "comma-separated list of namespaces to watch")
+	flag.String("cis-metrics-labels", "", "comma-separated list of labels in CIS resources to create metrics labels for")
 	flag.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
 	flag.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
 	flag.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
@@ -112,12 +110,7 @@ func main() {
 		LeaderElectionID:       "398aa7bc.statnett.no",
 	}
 
-	namespaces := []string{}
-	if err := viper.UnmarshalKey(flagNamespaces, &namespaces); err != nil {
-		setupLog.Error(err, "unable to read in namespaces flag/env")
-		os.Exit(1)
-	}
-
+	namespaces := viper.GetStringSlice("namespaces")
 	if len(namespaces) > 0 {
 		options.NewCache = cache.MultiNamespacedCacheBuilder(namespaces)
 	}
@@ -198,12 +191,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cisMetricsLabels := []string{}
-	if err := viper.UnmarshalKey(flagCISMetricsLabels, &cisMetricsLabels); err != nil {
-		setupLog.Error(err, "unable to read in cis-metrics-labels flag/env")
-		os.Exit(1)
-	}
-
+	cisMetricsLabels := viper.GetStringSlice("cis-metrics-labels")
 	if err = (&metrics.ImageMetricsCollector{
 		Client: mgr.GetClient(),
 		Config: cfg,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,8 +51,8 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr, probeAddr                               string
-		helpRequested, enableLeaderElection, enableProfiling bool
+		metricsAddr, probeAddr                string
+		enableLeaderElection, enableProfiling bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -69,20 +69,14 @@ func main() {
 	flag.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
 	flag.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	flag.String("trivy-server", "", "The server to use in Trivy client/server mode.")
+	flag.Bool("help", false, "print out usage and a summary of options")
 
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
-
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.BoolVarP(&helpRequested, "help", "h", false, "print out usage and a summary of options")
 	pflag.Parse()
-
-	if helpRequested {
-		pflag.Usage()
-		os.Exit(0)
-	}
 
 	err := viper.BindPFlags(pflag.CommandLine)
 	if err != nil {
@@ -92,6 +86,11 @@ func main() {
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	if viper.GetBool("help") {
+		pflag.Usage()
+		os.Exit(0)
+	}
 
 	cfg := operator.Config{}
 	if err := viper.Unmarshal(&cfg); err != nil {


### PR DESCRIPTION
This PR is the first step towards splitting up the main func. I have tried to use a consistent code-style where the goal is to separate the function into the following parts:

1. Configure all supported flags. This will serve as the base for operator configuration.
2. Wiring up the config components, tying together flags, pflags and viper including the configuration of these.
3. Validation of configuration.
4. Bootstrapping the operator based on the configuration using viper.

Relates to #81 