### PR TITLE
refactor: move config properties to Config struct

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,9 +114,8 @@ func main() {
 		LeaderElectionID:       "398aa7bc.statnett.no",
 	}
 
-	namespaces := viper.GetStringSlice("namespaces")
-	if len(namespaces) > 0 {
-		options.NewCache = cache.MultiNamespacedCacheBuilder(namespaces)
+	if len(cfg.ScanNamespaces) > 0 {
+		options.NewCache = cache.MultiNamespacedCacheBuilder(cfg.ScanNamespaces)
 	}
 
 	kubeConfig := ctrl.GetConfigOrDie()
@@ -196,11 +195,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	cisMetricsLabels := viper.GetStringSlice("cis-metrics-labels")
 	if err = (&metrics.ImageMetricsCollector{
 		Client: mgr.GetClient(),
 		Config: cfg,
-	}).SetupWithManager(mgr, cisMetricsLabels...); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to set up image metrics collector")
 		os.Exit(1)
 	}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -50,13 +50,13 @@ type ImageMetricsCollector struct {
 	patchStatusDesc *prometheus.Desc
 }
 
-func (c *ImageMetricsCollector) SetupWithManager(mgr manager.Manager, metricsLabels ...string) error {
-	labels := make(cisLabels, 0, len(metricsLabels)+len(cisResourceLabels)+1)
+func (c *ImageMetricsCollector) SetupWithManager(mgr manager.Manager) error {
+	labels := make(cisLabels, 0, len(c.MetricsLabels)+len(cisResourceLabels)+1)
 
-	if len(metricsLabels) > 0 {
+	if len(c.MetricsLabels) > 0 {
 		re := regexp.MustCompile("[^a-zA-Z0-9_]+")
 
-		for _, l := range metricsLabels {
+		for _, l := range c.MetricsLabels {
 			labelKey := l
 			cl := cisLabel{
 				name: re.ReplaceAllString(labelKey, "_"),

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
+	"github.com/statnett/image-scanner-operator/pkg/operator"
 )
 
 var _ = Describe("ContainerImageScan Collector", func() {
@@ -21,8 +22,9 @@ var _ = Describe("ContainerImageScan Collector", func() {
 		c := newClientWithTestdata()
 		imageMetricsCollector = &ImageMetricsCollector{
 			Client: c,
+			Config: operator.Config{MetricsLabels: []string{"system.statnett.no/name", "app.kubernetes.io/name"}},
 		}
-		Expect(imageMetricsCollector.SetupWithManager(&fakeManager{}, "system.statnett.no/name", "app.kubernetes.io/name")).To(Succeed())
+		Expect(imageMetricsCollector.SetupWithManager(&fakeManager{})).To(Succeed())
 	})
 
 	AssertNoLintIssues := func() {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -7,9 +7,11 @@ import (
 )
 
 type Config struct {
+	MetricsLabels         []string      `mapstructure:"cis-metrics-labels"`
 	ScanInterval          time.Duration `mapstructure:"scan-interval"`
 	ScanJobNamespace      string        `mapstructure:"scan-job-namespace"`
 	ScanJobServiceAccount string        `mapstructure:"scan-job-service-account"`
+	ScanNamespaces        []string      `mapstructure:"namespaces"`
 	ScanWorkloadResources []string      `mapstructure:"scan-workload-resources"`
 	TrivyImage            string        `mapstructure:"trivy-image"`
 	TrivyServer           string        `mapstructure:"trivy-server"`


### PR DESCRIPTION
This moves the remaining operator config properties into the `Config` struct to improve consistency in the code. We should probably have a brush-up of the flag naming, but that will have to be in a follow-up PR.

Relates to #81  