### PR TITLE
ci: embed image build in e2e-test job

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -2,9 +2,10 @@
 name: Build image
 on:
   push:
+    branches:
+      - main
     tags:
       - v*
-  workflow_call: {}
 permissions:
   contents: read
 env:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,15 +1,10 @@
 ---
-name: Build
+name: Build image
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
+  workflow_call: {}
 permissions:
   contents: read
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import "${{ env.IMG }}" --cluster image-scanner --mode direct
+          docker images
+          k3d image import ${{ env.IMG }} --cluster image-scanner
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
+          docker images
           k3d image import ${{ env.IMG }} --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true
   build-image:
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,12 @@ jobs:
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true
+  build-image:
+    uses: ./.github/workflows/build-image.yaml
   e2e-test:
-    needs: verify-generated
+    needs:
+      - verify-generated
+      - build-image
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,14 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: type=docker,dest=images/operator-image.tar
+          outputs: type=docker,dest=/tmp/operator-image.tar
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: images
-          path: images/
+          name: operator-image
+          path: /tmp/operator-image.tar
   e2e-test:
     needs:
       - verify-generated
@@ -130,8 +130,8 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: images
-          path: images/
+          name: operator-image
+          path: /tmp/
       - run: |
           mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
@@ -144,7 +144,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import ${{ env.IMG }} ./images/operator-image.tar --cluster image-scanner --mode direct
+          k3d image import ${{ env.IMG }} /tmp/operator-image.tar --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          push: false
+          outputs: type=image,push=false
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
+          outputs: image
           push: false
           tags: ${{ env.IMG }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,14 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: type=image,push=false
+          outputs: type=docker,dest=images/operator-image.tar
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: images
+          path: images/
   e2e-test:
     needs:
       - verify-generated
@@ -124,6 +128,10 @@ jobs:
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: images
+          path: images/
       - run: |
           mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
@@ -136,8 +144,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          docker images
-          k3d image import ${{ env.IMG }} --cluster image-scanner --mode direct
+          k3d image import ${{ env.IMG }} ./images/operator-image.tar --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: ype=image,push=false
+          outputs: type=image,push=false
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ concurrency:
   cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
-env:
-  IMG: image-scanner/controller:latest
 jobs:
   golangci-lint:
     permissions:
@@ -99,6 +97,10 @@ jobs:
   e2e-test:
     needs: verify-generated
     runs-on: ubuntu-latest
+    env:
+      IMG: image-scanner/controller:latest
+      IMG_FILE: operator-image.tar
+      K3D_CLUSTER: image-scanner
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
@@ -112,13 +114,13 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: type=docker,dest=operator-image.tar
+          outputs: type=docker,dest=${{ env.IMG_FILE }}
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
-          cluster-name: image-scanner
+          cluster-name: ${{ env.K3D_CLUSTER }}
           args: >-
             --config=test/e2e-config/k3d-config.yml
             --volume=/tmp/pod-logs:/var/log/pods
@@ -126,7 +128,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import operator-image.tar --cluster image-scanner
+          k3d image import ${{ env.IMG_FILE }} --cluster ${{ env.K3D_CLUSTER }}
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - run: |
-          mkdir /tmp/pod-logs
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
@@ -118,6 +116,8 @@ jobs:
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - run: |
+          mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: ${{ env.K3D_CLUSTER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ concurrency:
   cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
+env:
+  IMG: image-scanner/controller:latest
 jobs:
   golangci-lint:
     permissions:
@@ -108,7 +110,7 @@ jobs:
         with:
           context: .
           push: false
-          tags: image-scanner/controller:latest
+          tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
   e2e-test:
@@ -134,6 +136,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
+          k3d image import --cluster image-scanner ${{ env.IMG }}
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import ${{ env.IMG }} --cluster image-scanner --mode direct
+          k3d image import "${{ env.IMG }}" --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,7 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: image
-          push: false
+          outputs: ype=image,push=false
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import --cluster image-scanner ${{ env.IMG }}
+          k3d image import ${{ env.IMG }} --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: type=image,push=false
+          outputs: type=docker,dest=operator-image.tar
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -126,8 +126,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          docker images
-          k3d image import ${{ env.IMG }} --cluster image-scanner
+          k3d image import operator-image.tar --cluster image-scanner
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,20 +95,21 @@ jobs:
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true
   build-image:
-    - name: Harden Runner
-      uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
-    - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
-    - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
-      with:
-        context: .
-        push: false
-        tags: image-scanner/controller:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+      - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
+        with:
+          context: .
+          push: false
+          tags: image-scanner/controller:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   e2e-test:
     needs:
       - verify-generated
@@ -133,9 +134,6 @@ jobs:
           kubectl version --output=yaml
       - run: |
           make deploy-dependencies deploy
-        env:
-          # Poor man's ternary expression; Image tag format differs for pull requests and branch pushes
-          IMG: ghcr.io/statnett/image-scanner-operator:${{ github.head_ref && format('pr-{0}', github.event.number) || github.ref_name }}
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,20 @@ jobs:
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true
   build-image:
-    uses: ./.github/workflows/build-image.yaml
+    - name: Harden Runner
+      uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+    - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+    - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
+      with:
+        context: .
+        push: false
+        tags: image-scanner/controller:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
   e2e-test:
     needs:
       - verify-generated
@@ -106,7 +119,6 @@ jobs:
         uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - run: |
           mkdir /tmp/pod-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true
-  build-image:
+  e2e-test:
+    needs: verify-generated
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -104,36 +105,17 @@ jobs:
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - run: |
+          mkdir /tmp/pod-logs
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
       - uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           context: .
-          outputs: type=docker,dest=/tmp/operator-image.tar
+          push: false
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: operator-image
-          path: /tmp/operator-image.tar
-  e2e-test:
-    needs:
-      - verify-generated
-      - build-image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: operator-image
-          path: /tmp/
-      - run: |
-          mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: image-scanner
@@ -144,7 +126,7 @@ jobs:
           kubectl cluster-info
           kubectl version --output=yaml
       - run: |
-          k3d image import ${{ env.IMG }} /tmp/operator-image.tar --cluster image-scanner --mode direct
+          k3d image import ${{ env.IMG }} --cluster image-scanner --mode direct
           make deploy-dependencies deploy
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:


### PR DESCRIPTION
I suspect that running the e2e-test image in a pull_request_target might mess up something, ref. #119. This PR embeds the image building in the e2e-test job.

Update: I think understand what might have happened on the PR that got merged with error: After simulating the error on this branch, I notice that building the image takes considerable time. This could result in the e2e-tests running on an outdated digest for the PR tag (race condition).

![image](https://user-images.githubusercontent.com/1142578/214361869-7974fc2f-90a9-40b3-96f1-cb583a9b57ec.png)

It is [not possible to have job dependencies across workflows](https://github.com/orgs/community/discussions/26632#discussioncomment-3252616), so I think we are better off with the approach suggested in this PR. If we still want to get GHCR image tags for pull requests, I think we have to do the e2e-testing in the same workflow as the image build.

Close #119 