### PR TITLE
chore: init Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":semanticCommitTypeAll(build)",
+    "regexManagers:dockerfileVersions"
+  ],
+  "golang": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Renovate config with Go and GitHub-actions disabled, as these will be handled by Dependabot.

Closing #127 

All commits will be of semantic type `build(deps)` because of [the preset `:semanticCommitTypeAll(build)`](https://docs.renovatebot.com/presets-default/#semanticcommittypeallarg0).