### PR TITLE
chore: adjust semanticCommitTypeAll Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    ":semanticCommitTypeAll(build)",
+    ":semanticCommitTypeAll(ci)",
     "regexManagers:dockerfileVersions"
   ],
   "golang": {


### PR DESCRIPTION
At present it seems to me like Renovate will suggest PRs for ci, and not build, dependencies. To avoid these popping up in the release notes, without adjusting the PR titles, I suggest making ci the default `semanticCommitTypeAll` in the Renovate config.

Also moving the file to .github directory to avoid having too many files in the root directory.