### PR TITLE
chore(renovate): add 'dependencies' label to PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     ":semanticCommitTypeAll(ci)",
     "regexManagers:dockerfileVersions"
   ],
+  "labels": ["dependencies"],
   "golang": {
     "enabled": false
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,5 +11,5 @@
   },
   "github-actions": {
     "enabled": false,
-  }
+  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,13 +3,13 @@
   "extends": [
     "config:base",
     ":semanticCommitTypeAll(ci)",
-    "regexManagers:dockerfileVersions"
+    "regexManagers:dockerfileVersions",
   ],
   "labels": ["dependencies"],
   "golang": {
-    "enabled": false
+    "enabled": false,
   },
   "github-actions": {
-    "enabled": false
+    "enabled": false,
   }
 }


### PR DESCRIPTION
Dependabot adds the label `dependencies` to all PRs, adding it here as well to make it consistent.

Also renaming file to json5, to support trailing commas and comments.