### PR TITLE
fix: init temporary logger to print errors during startup

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -45,7 +45,7 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(stasv1alpha1.AddToScheme(scheme))
 
-	ctrl.SetLogger(ctrlzap.New())
+	ctrl.SetLogger(ctrlzap.New(ctrlzap.ConsoleEncoder()))
 }
 
 type Operator struct{}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
@@ -43,6 +44,8 @@ func init() {
 
 	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(stasv1alpha1.AddToScheme(scheme))
+
+	ctrl.SetLogger(ctrlzap.New())
 }
 
 type Operator struct{}


### PR DESCRIPTION
Closes #142.

Before the logger
```
➜  image-scanner-operator git:(init-logger) ✗ ./bin/manager
```
After the call to SetupLogger (console encoder)
```
  image-scanner-operator git:(init-logger) ✗ ./bin/manager
2023-01-26T15:35:50.911+0100	INFO	setup	required flag/env not set	{"flag": "scan-job-namespace", "env": "SCAN_JOB_NAMESPACE"}
```

With the SetupLogger with the default Json Encoder
```
➜  image-scanner-operator git:(init-logger) ✗ ./bin/manager
{"level":"info","ts":"2023-01-26T14:25:13+01:00","logger":"setup","msg":"required flag/env not set","flag":"scan-job-namespace","env":"SCAN_JOB_NAMESPACE"}
```

