### PR TITLE
chore: enable renovating of rancher/k3s image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,4 +12,14 @@
   "github-actions": {
     "enabled": false,
   },
+  "regexManagers": [
+    {
+      "fileMatch": [".+\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate-image:( versioning=(?<versioning>.*?))?\\n\\s*(.+?_IMAGE|image): (?<depName>.+?):(?<currentValue>.+?)(\\s|$)",
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
+    },
+  ],
 }

--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -3,4 +3,5 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: image-scanner
+# renovate-image: versioning=regex:v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<compatibility>k3s)(?<build>\d+)(\s|$)
 image: docker.io/rancher/k3s:v1.26.0-k3s2


### PR DESCRIPTION
Closing #144 

This does two things:

* adding a new regex manager that can be used in YAML files where we have dependencies on the form (with examples of using this regex manager in the comment):
  * ```yaml
    # renovate-image:
    image: some-docker/image:v3.0.0-slim
    ```
  * ```yaml
    # renovate-image: versioning=regex:v(?<major>\d+)(\s|$)
    SOME_IMAGE: another-image/foo:v8
    ```
* applies this new regex manager to the k3s image

