### PR TITLE
chore(renovate): un-ignore 'test' folder

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     "regexManagers:dockerfileVersions",
   ],
   "labels": ["dependencies"],
+  "ignorePaths": [],
   "golang": {
     "enabled": false,
   },


### PR DESCRIPTION
Renovate is currently ignoring:

```json
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
```

This makes Renovate skip all updates in https://github.com/statnett/image-scanner-operator/tree/main/test.