### PR TITLE
feat(cli): make regexp for included namespace configurable

### DIFF
--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -3,6 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../default
+configMapGenerator:
+  - name: config
+    behavior: merge
+    literals:
+      # Only include kuttl namespace pattern to reduce resource waste running e2e tests
+      - SCAN_NAMESPACE_INCLUDE_REGEXP=^kuttl-.*
 patches:
   # FIXME: Somehow sessionAffinity does not work when running e2e tests in some environments
   # Disable trivy server sessionAffinity; not really needed when running a single replica

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ScanJobServiceAccount      string         `mapstructure:"scan-job-service-account"`
 	ScanNamespaces             []string       `mapstructure:"namespaces"`
 	ScanNamespaceExcludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
+	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
 	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
 	TrivyImage                 string         `mapstructure:"trivy-image"`
 	Zap                        zap.Options    `mapstructure:"-"`

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -66,6 +66,9 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+	if r.ScanNamespaceIncludeRegexp != nil {
+		predicates = append(predicates, namespaceMatchRegexp(r.ScanNamespaceIncludeRegexp))
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&stasv1alpha1.ContainerImageScan{},

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -66,6 +66,7 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+
 	if r.ScanNamespaceIncludeRegexp != nil {
 		predicates = append(predicates, namespaceMatchRegexp(r.ScanNamespaceIncludeRegexp))
 	}

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -68,6 +68,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+
 	if r.ScanNamespaceIncludeRegexp != nil {
 		predicates = append(predicates, namespaceMatchRegexp(r.ScanNamespaceIncludeRegexp))
 	}

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -68,6 +68,9 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))
 	}
+	if r.ScanNamespaceIncludeRegexp != nil {
+		predicates = append(predicates, namespaceMatchRegexp(r.ScanNamespaceIncludeRegexp))
+	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{},

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -61,6 +61,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
 	fs.String("scan-workload-resources", "", "comma-separated list of workload resources to scan")
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
+	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 


### PR DESCRIPTION
This adds a configurable opt-in to include namespaces by regexp. Also reconfiguring the e2e-tests to only include kuttl-namespaces.