### PR TITLE
fix!: should have unique config map names

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ from the ConfigMap in the default Image Scanner configuration using a
 
 ```yaml
 configMapGenerator:
-  - name: image-scanner
+  - name: image-scanner-config
     behavior: merge
     literals:
       - CIS_METRICS_LABELS=app.kubernetes.io/name

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ from the ConfigMap in the default Image Scanner configuration using a
 
 ```yaml
 configMapGenerator:
-  - name: config
+  - name: image-scanner
     behavior: merge
     literals:
       - CIS_METRICS_LABELS=app.kubernetes.io/name

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,6 @@ replacements:
     targets:
       - select:
           kind: ConfigMap
-          name: config
+          name: image-scanner
         fieldPaths:
           - data.TRIVY_IMAGE

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,6 @@ replacements:
     targets:
       - select:
           kind: ConfigMap
-          name: image-scanner
+          name: image-scanner-config
         fieldPaths:
           - data.TRIVY_IMAGE

--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../default
 configMapGenerator:
-  - name: config
+  - name: image-scanner
     behavior: merge
     literals:
       # Only include kuttl namespace pattern to reduce resource waste running e2e tests

--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../default
 configMapGenerator:
-  - name: image-scanner
+  - name: image-scanner-config
     behavior: merge
     literals:
       # Only include kuttl namespace pattern to reduce resource waste running e2e tests

--- a/config/image-scanner-jobs/kustomization.yaml
+++ b/config/image-scanner-jobs/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - resource_quota.yaml
   - service_account.yaml
 configMapGenerator:
-  - name: trivy-job
+  - name: trivy-job-config
     literals:
       - OFFLINE_SCAN=true
       - SERVER=http://trivy.image-scanner.svc.cluster.local

--- a/config/image-scanner-jobs/kustomization.yaml
+++ b/config/image-scanner-jobs/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - resource_quota.yaml
   - service_account.yaml
 configMapGenerator:
-  - name: trivy
+  - name: trivy-job
     literals:
       - OFFLINE_SCAN=true
       - SERVER=http://trivy.image-scanner.svc.cluster.local

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
       - ZAP_ENCODER=json
       - ZAP_LOG_LEVEL=info
       - ZAP_TIME_ENCODING=iso8601
-    name: config
+    name: image-scanner
 images:
   - name: controller
     newName: registry.dummy-domain.com/image-scanner/controller

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
       - ZAP_ENCODER=json
       - ZAP_LOG_LEVEL=info
       - ZAP_TIME_ENCODING=iso8601
-    name: image-scanner
+    name: image-scanner-config
 images:
   - name: controller
     newName: registry.dummy-domain.com/image-scanner/controller

--- a/config/manager/manager_patch.yaml
+++ b/config/manager/manager_patch.yaml
@@ -13,7 +13,7 @@ spec:
             - --leader-elect
           envFrom:
             - configMapRef:
-                name: config
+                name: image-scanner
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/config/manager/manager_patch.yaml
+++ b/config/manager/manager_patch.yaml
@@ -13,7 +13,7 @@ spec:
             - --leader-elect
           envFrom:
             - configMapRef:
-                name: image-scanner
+                name: image-scanner-config
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/config/trivy-server/kustomization.yaml
+++ b/config/trivy-server/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
   app.kubernetes.io/name: trivy
   app.kubernetes.io/component: server
 configMapGenerator:
-  - name: trivy-server
+  - name: trivy-server-config
     literals:
       - LISTEN=0.0.0.0:4954
       - CACHE_DIR=/home/scanner/.cache/trivy

--- a/config/trivy-server/kustomization.yaml
+++ b/config/trivy-server/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
   app.kubernetes.io/name: trivy
   app.kubernetes.io/component: server
 configMapGenerator:
-  - name: trivy
+  - name: trivy-server
     literals:
       - LISTEN=0.0.0.0:4954
       - CACHE_DIR=/home/scanner/.cache/trivy

--- a/config/trivy-server/stateful_set.yaml
+++ b/config/trivy-server/stateful_set.yaml
@@ -25,7 +25,7 @@ spec:
             - server
           envFrom:
             - configMapRef:
-                name: trivy
+                name: trivy-server
               prefix: TRIVY_
           ports:
             - name: http

--- a/config/trivy-server/stateful_set.yaml
+++ b/config/trivy-server/stateful_set.yaml
@@ -25,7 +25,7 @@ spec:
             - server
           envFrom:
             - configMapRef:
-                name: trivy-server
+                name: trivy-server-config
               prefix: TRIVY_
           ports:
             - name: http

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -68,7 +68,7 @@ spec:
           envFrom:
             - prefix: TRIVY_
               configMapRef:
-                name: trivy
+                name: trivy-job
           image: docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
           imagePullPolicy: IfNotPresent
           name: scan-image

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -68,7 +68,7 @@ spec:
           envFrom:
             - prefix: TRIVY_
               configMapRef:
-                name: trivy-job
+                name: trivy-job-config
           image: docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
           imagePullPolicy: IfNotPresent
           name: scan-image

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -197,7 +197,7 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 			Prefix: "TRIVY_",
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "trivy",
+					Name: "trivy-job",
 				},
 			},
 		},

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -197,7 +197,7 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 			Prefix: "TRIVY_",
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "trivy-job",
+					Name: "trivy-job-config",
 				},
 			},
 		},


### PR DESCRIPTION
When upgrading to the 0.2.0 release, I noticed that I had to qualify configmaps with namespace because both the Trivy server and Trivy jobs config map is named `trivy`.

BREAKING CHANGE: This renames all configmaps which will require changes if kustomized.