### PR TITLE
fix: make logger configurable again

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,9 @@ import (
 	"log"
 
 	"github.com/spf13/pflag"
+	"github.com/statnett/controller-runtime-viper/pkg/zap"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/statnett/image-scanner-operator/internal/config"
 	"github.com/statnett/image-scanner-operator/internal/operator"
@@ -12,15 +15,21 @@ import (
 
 func main() {
 	cfg := config.Config{}
-	cfg.Zap.Development = true
+	opts := zap.Options{Development: true}
 
 	opr := operator.Operator{}
+
+	opts.BindFlags(flag.CommandLine)
 	if err := opr.BindFlags(&cfg, flag.CommandLine); err != nil {
 		log.Fatal(err)
 	}
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
+	klog.SetLogger(logger)
 
 	if err := opr.UnmarshalConfig(&cfg); err != nil {
 		log.Fatal(err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,11 +16,9 @@ import (
 func main() {
 	cfg := config.Config{}
 	opts := zap.Options{Development: true}
-
-	opr := operator.Operator{}
-
 	opts.BindFlags(flag.CommandLine)
 
+	opr := operator.Operator{}
 	if err := opr.BindFlags(&cfg, flag.CommandLine); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ func main() {
 	opr := operator.Operator{}
 
 	opts.BindFlags(flag.CommandLine)
+
 	if err := opr.BindFlags(&cfg, flag.CommandLine); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,8 +4,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/statnett/controller-runtime-viper/pkg/zap"
-
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
@@ -19,7 +17,6 @@ type Config struct {
 	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
 	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
 	TrivyImage                 string         `mapstructure:"trivy-image"`
-	Zap                        zap.Options    `mapstructure:"-"`
 }
 
 func (c Config) TimeUntilNextScan(cis *stasv1alpha1.ContainerImageScan) time.Duration {

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -12,12 +12,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/statnett/controller-runtime-viper/pkg/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -65,8 +63,6 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
-	cfg.Zap.BindFlags(fs)
-
 	pfs := &pflag.FlagSet{}
 	pfs.AddGoFlagSet(fs)
 
@@ -108,10 +104,6 @@ func (o Operator) ValidateConfig(cfg config.Config) error {
 }
 
 func (o Operator) Start(cfg config.Config) error {
-	logger := zap.New(zap.UseFlagOptions(&cfg.Zap))
-	ctrl.SetLogger(logger)
-	klog.SetLogger(logger)
-
 	metricsAddr := viper.GetString("metrics-bind-address")
 	probeAddr := viper.GetString("health-probe-bind-address")
 	enableLeaderElection := viper.GetBool("leader-elect")


### PR DESCRIPTION
Somehow during the refactoring on the main func, we seem to have lost the ability to configure the zap-logger. Example:

```
2023-02-01T21:30:08.363Z INFO Reconciling {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"max-job-27921450-z76pf","namespace":"deploy-playground"}, "namespace": "deploy-playground", "name": "max-job-27921450-z76pf", "reconcileID": "88f4129d-f48e-42eb-9399-42595c88089a"}
2023-02-01T21:31:10.330Z INFO Reconciling {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"max-job-1-27921451-ql76l","namespace":"deploy-playground"}, "namespace": "deploy-playground", "name": "max-job-1-27921451-ql76l", "reconcileID": "85b367b0-2122-4db3-8892-d5be0b9136a7"}
2023-02-01T21:31:10.374Z INFO Reconciling {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"max-job-27921451-jlw65","namespace":"deploy-playground"}, "namespace": "deploy-playground", "name": "max-job-27921451-jlw65", "reconcileID": "94b1a3f2-9a15-41ef-b98d-733446d2d402"}
2023-02-01T21:31:14.434Z INFO Reconciling {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"max-job-27921451-jlw65","namespace":"deploy-playground"}, "namespace": "deploy-playground", "name": "max-job-27921451-jlw65", "reconcileID": "d806fbe8-b91d-42f8-8810-be1a1a76ed88"}
2023-02-01T21:31:14.535Z INFO Reconciling {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"max-job-1-27921451-ql76l","namespace":"deploy-playground"}, "namespace": "deploy-playground", "name": "max-job-1-27921451-ql76l", "reconcileID": "78487538-6aab-482d-a4e0-5da2995a3d25"}
```

Suggesting to revert to something simpler for now where logging is fully configured in main.