### PR TITLE
chore: renovate trivy docker image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
     {
       "fileMatch": [".+\\.ya?ml$"],
       "matchStrings": [
-        "# renovate-image:( versioning=(?<versioning>.*?))?\\n\\s*(.+?_IMAGE|image): (?<depName>.+?):(?<currentValue>.+?)(\\s|$)",
+        "# renovate-image:( versioning=(?<versioning>.*?))?\\n\\s*(.+?_IMAGE|image)[=:]\\s*(?<depName>.+?):(?<currentValue>.+?)(\\s|$)",
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,6 +8,7 @@ configMapGenerator:
   - literals:
       - CIS_METRICS_LABELS=app.kubernetes.io/name
       - SCAN_INTERVAL=12h
+      # renovate-image:
       - TRIVY_IMAGE=ghcr.io/aquasecurity/trivy:0.36.1
       - SCAN_JOB_NAMESPACE=image-scanner-jobs
       - SCAN_JOB_SERVICE_ACCOUNT=image-scanner

--- a/config/trivy-server/stateful_set.yaml
+++ b/config/trivy-server/stateful_set.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       containers:
         - name: server
+          # renovate-image:
           image: ghcr.io/aquasecurity/trivy:0.36.1
           args:
             - server


### PR DESCRIPTION
Closes https://github.com/statnett/image-scanner-operator/issues/162

This will make Renovate suggest updates for `ghcr.io/aquasecurity/trivy`.

A minor change was needed for the matcher regex to support `=` symbol.
