### PR TITLE
chore: remove obsolete Trivy server config

### DIFF
--- a/config/trivy-server/kustomization.yaml
+++ b/config/trivy-server/kustomization.yaml
@@ -14,6 +14,4 @@ configMapGenerator:
     literals:
       - LISTEN=0.0.0.0:4954
       - CACHE_DIR=/home/scanner/.cache/trivy
-      - DEBUG=false
-      - SKIP_UPDATE=false
       - DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db


### PR DESCRIPTION
Since they configure the default value. And `SKIP_UPDATE` is also deprecated in Trivy 0.37.x +.