### PR TITLE
test(e2e): reduce number of parallel running tests

### DIFF
--- a/test/e2e-config/kuttl-test.yaml
+++ b/test/e2e-config/kuttl-test.yaml
@@ -9,4 +9,4 @@ testDirs:
 timeout: 240
 reportFormat: xml
 # FIXME: Reduced number of test in parallel to mend e2e test issues on GitHub runners
-parallel: 2
+parallel: 1

--- a/test/e2e-config/kuttl-test.yaml
+++ b/test/e2e-config/kuttl-test.yaml
@@ -8,3 +8,5 @@ testDirs:
   - test/e2e/workload-scan
 timeout: 240
 reportFormat: xml
+# FIXME: Reduced number of test in parallel to mend e2e test issues on GitHub runners
+parallel: 2


### PR DESCRIPTION
This PR is an attempt to make the e2e-tests on GH runners more stable. Ref. https://kuttl.dev/docs/testing/reference.html#testsuite (parallel)