### PR TITLE
fix: don't override user logging configuration

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
@@ -39,8 +38,6 @@ func init() {
 
 	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(stasv1alpha1.AddToScheme(scheme))
-
-	ctrl.SetLogger(ctrlzap.New(ctrlzap.ConsoleEncoder()))
 }
 
 type Operator struct{}


### PR DESCRIPTION
This overwrites the logger setup via user input.

Signed-off-by: Sunil Shivanand <padlar@live.com>

Output after the fix

```
➜  image-scanner-operator git:(fix-json-logging) ✗ make build && ZAP_ENCODER=console ZAP_LOG_LEVEL=info SCAN_JOB_NAMESPACE=default ./bin/manager
test -s /Users/padlar/sandbox/image-scanner-operator/bin/controller-gen && /Users/padlar/sandbox/image-scanner-operator/bin/controller-gen --version | grep -q v0.11.1 || \
	GOBIN=/Users/padlar/sandbox/image-scanner-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1
/Users/padlar/sandbox/image-scanner-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go build -o bin/manager cmd/main.go
1.675378643643044e+09	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
1.675378643644398e+09	INFO	starting manager
1.675378643644601e+09	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
1.675378643644602e+09	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
1.675378643745528e+09	INFO	Starting EventSource	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "source": "kind source: *v1.Pod"}
1.675378643745547e+09	INFO	Starting EventSource	{"controller": "containerimagescan", "controllerGroup": "stas.statnett.no", "controllerKind": "ContainerImageScan", "source": "kind source: *v1alpha1.ContainerImageScan"}
1.67537864374602e+09	INFO	Starting EventSource	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "source": "kind source: *v1alpha1.ContainerImageScan"}
1.675378643746094e+09	INFO	Starting Controller	{"controller": "containerimagescan", "controllerGroup": "stas.statnett.no", "controllerKind": "ContainerImageScan"}
```

```
➜  image-scanner-operator git:(fix-json-logging) ✗ make build && ZAP_ENCODER=json ZAP_LOG_LEVEL=info SCAN_JOB_NAMESPACE=default ./bin/manager
test -s /Users/padlar/sandbox/image-scanner-operator/bin/controller-gen && /Users/padlar/sandbox/image-scanner-operator/bin/controller-gen --version | grep -q v0.11.1 || \
	GOBIN=/Users/padlar/sandbox/image-scanner-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1
/Users/padlar/sandbox/image-scanner-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go build -o bin/manager cmd/main.go
{"level":"info","ts":1675378671.786262,"logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":1675378671.787885,"msg":"starting manager"}
{"level":"info","ts":1675378671.788225,"msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:8080"}
{"level":"info","ts":1675378671.788225,"msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":1675378671.888649,"msg":"Starting EventSource","controller":"pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"info","ts":1675378671.8886552,"msg":"Starting EventSource","controller":"job","controllerGroup":"batch","controllerKind":"Job","source":"kind source: *v1.Job"}
```

