### PR TITLE
chore(renovate): trivy PRs should have 'build' title

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,14 @@
   "github-actions": {
     "enabled": false,
   },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ghcr.io/aquasecurity/trivy",
+      ],
+      "semanticCommitType": "build",
+    },
+  ],
   "regexManagers": [
     {
       "fileMatch": [".+\\.ya?ml$"],


### PR DESCRIPTION
Closes https://github.com/statnett/image-scanner-operator/issues/173

This will make upcoming PRs for trivy look like:

```
build(deps): update ghcr.io/aquasecurity/trivy docker tag to v0.37.1
```

instead of 

```
ci(deps): update ghcr.io/aquasecurity/trivy docker tag to v0.37.1
```