### PR TITLE
chore(renovate): add universal regex and match k3d/kuttl

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,13 @@
   ],
   "regexManagers": [
     {
+      "fileMatch": [".*"],
+      "matchStrings": [
+        "renovate:\\s+datasource=(?<datasource>\\S+?) depName=(?<depName>\\S+?)( versioning=(?<versioning>\\S+?))?( registryUrl=(?<registryUrl>\\S+?))?\\s+(\\S+?_)?(VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*(?<currentValue>\\S+)",
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    {
       "fileMatch": [".+\\.ya?ml$"],
       "matchStrings": [
         "# renovate-image:( versioning=(?<versioning>.*?))?\\n\\s*(.+?_IMAGE|image)[=:]\\s*(?<depName>.+?):(?<currentValue>.+?)(\\s|$)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
       IMG: registry.dummy-domain.com/image-scanner/controller:latest
       IMG_FILE: operator-image.tar
       K3D_CLUSTER: image-scanner
+      # renovate: datasource=github-tags depName=k3d-io/k3d
       K3D_VERSION: v5.4.7
     steps:
       - name: Harden Runner
@@ -135,6 +136,7 @@ jobs:
       - uses: jaxxstorm/action-install-gh-release@f2bcf7617d36fea65f0a9d261d4947b19947956e # v1.9.0
         with:
           repo: kudobuilder/kuttl
+          # renovate: datasource=github-tags depName=kudobuilder/kuttl
           tag: v0.15.0
           cache: enable
       - run: |


### PR DESCRIPTION
Closes https://github.com/statnett/image-scanner-operator/issues/175

Adding the "universal" regex matcher we have previously used on-premises.

Using this universal matcher to make renovate match k3d and kuttl.

This matcher will match all of these:

* ```
  renovate: datasource=something depName=something
  version: 0.0.0
  ```
* ```
  renovate: datasource=some-datasource depName=any-depname versioning=some-versioning
  SOME_VERSION: 0.0.0
  ```
* ```
  renovate: datasource=something depName=something
  tag: 0.0.0
  ```
* ```
  renovate: datasource=something depName=something registryUrl=custom-registry
  another_tag: 0.0
  ```
* ```
  renovate: datasource=something depName=something versioning=some-versioning registryUrl=custom-registry
  ANY_TAG: 0
  ```

and many more variants.
