### PR TITLE
ci(test): use ginkgo to run go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
           cache: true
       - name: Install ginkgo
         run: |
-          command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
+          command -v ginkgo || go install -v github.com/onsi/ginkgo/v2/ginkgo@${{ env.GINKGO_VERSION }}
         env:
-          GINKGO_VERSION: "v2.8.0"
+          GINKGO_VERSION: v2.8.0
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install ginkgo
+        run: |
+          command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
+        env:
+          GINKGO_VERSION: "v2.8.0"
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 1. Run `make test` to run both unit and integrations (envtest) tests. [envtest][envtest] runs etcd and apiserver
    locally without the need for a real Kubernetes cluster. It helps to test the controller and the reconciliation logic.
+   Note: Requires `ginkgo` binary to run the tests:
+   ```shell
+   go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+   ```
 
 1. Optionally, run the e2e-tests. The e2e tests assumes that you have a working kubernetes cluster (e.g. kind or k3s cluster)
    and `KUBECONFIG` environment variable is pointing to that cluster configuration file. For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 1. Run `make test` to run both unit and integrations (envtest) tests. [envtest][envtest] runs etcd and apiserver
    locally without the need for a real Kubernetes cluster. It helps to test the controller and the reconciliation logic.
    Note: Requires `ginkgo` binary to run the tests:
+
    ```shell
    go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
    Note: Requires `ginkgo` binary to run the tests:
 
    ```shell
-   go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+   go install -v github.com/onsi/ginkgo/v2/ginkgo@latest
    ```
 
 1. Optionally, run the e2e-tests. The e2e tests assumes that you have a working kubernetes cluster (e.g. kind or k3s cluster)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" ginkgo -v --trace --repeat 3 --race ./... -coverprofile cover.out
 
 test-reports: test ## Run tests and generate reports (no reports for now)
 


### PR DESCRIPTION
enable trace and verbose modes. Run the test suite 3 times to debug flaky tests.

Related to #27.
