### PR TITLE
fix: handling of retried scan jobs

### DIFF
--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -100,7 +100,7 @@ var managedByImageScanner = predicate.NewPredicateFuncs(func(object client.Objec
 
 var jobIsFinished = predicate.NewPredicateFuncs(func(object client.Object) bool {
 	job := object.(*batchv1.Job)
-	return job.Status.Succeeded > 0 || job.Status.Failed > 0
+	return job.Status.Succeeded > 0 || job.Status.Failed >= *job.Spec.BackoffLimit
 })
 
 var cisVulnerabilityOverflow = predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -44,8 +44,7 @@ var _ = Describe("Workload controller", func() {
 			labels := map[string]string{"name": namespacedName.Name}
 
 			workload := workloadFactory(namespacedName, labels)
-			err := k8sClient.Create(ctx, workload)
-			Expect(err).To(Succeed())
+			Expect(k8sClient.Create(ctx, workload)).To(Succeed())
 
 			createPod(ctx, workload, k8sClient.Scheme())
 			expectedImage := stasv1alpha1.Image{


### PR DESCRIPTION
I noticed this error in one of our clusters today:

```json
{"level":"error","ts":"2023-02-07T14:45:41.079Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"deployment-ois-oracle-18-ois-oracle-18-ee805-e7962","namespace":"image-scanner-jobs"},"namespace":"image-scanner-jobs","name":"deployment-ois-oracle-18-ois-oracle-18-ee805-e7962","reconcileID":"ef8bfc2d-a040-41c7-9ea2-870f81694323","error":"expected number of job pods to be 1, got 3 ","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.2/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.2/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.2/pkg/internal/controller/controller.go:235"}
```

And I think we introduced retries on scan jobs without thinking carefully about the error handling.

This PR handles the fact that there might exist more than one pod per scan job. The logic suggests using the newest pod as the source of truth for the scan job result.