### PR TITLE
fix: never retry scan job

### DIFF
--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -17,7 +17,7 @@ metadata:
   name: echo-6bdfc76c56-8ae43-b63f8
 spec:
   activeDeadlineSeconds: 3600 # 1 hour
-  backoffLimit: 3
+  backoffLimit: 0
   completionMode: NonIndexed
   completions: 1
   parallelism: 1
@@ -117,7 +117,7 @@ spec:
           volumeMounts:
             - mountPath: /var/run/image-scanner
               name: image-scanner
-      restartPolicy: OnFailure
+      restartPolicy: Never
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: image-scanner

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -132,7 +132,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	job.Spec.Parallelism = pointer.Int32(1)
 	job.Spec.Completions = pointer.Int32(1)
 	job.Spec.ActiveDeadlineSeconds = pointer.Int64(int64(3600))
-	job.Spec.BackoffLimit = pointer.Int32(3)
+	job.Spec.BackoffLimit = pointer.Int32(0)
 	job.Spec.TTLSecondsAfterFinished = pointer.Int32(7200)
 	job.Spec.Template.Spec.ServiceAccountName = f.ScanJobServiceAccount
 
@@ -159,7 +159,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	}
 
 	job.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
-	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 
 	return job, nil
 }


### PR DESCRIPTION
Instead of fixing the code to handle scan job retries properly, ref. https://github.com/statnett/image-scanner-operator/pull/192, we decided to drop retries for now.
