### PR TITLE
test(e2e): fix test after image got more vulnerable

### DIFF
--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   digest: 'sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af'
   name: docker.io/kennship/http-echo
-  minSeverity: MEDIUM
+  minSeverity: HIGH
 status:
   vulnerabilitySummary:
     severityCount: {}


### PR DESCRIPTION
This test has been failing 100% for the last couple of days, and I was able to reproduce the problem locally. It seems like an update to the vuln DB has made the test image even more vulnerable.