### PR TITLE
fix: always set RequeueAfter when reconciling CIS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,6 @@ package config
 import (
 	"regexp"
 	"time"
-
-	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
 type Config struct {
@@ -17,12 +15,4 @@ type Config struct {
 	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
 	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
 	TrivyImage                 string         `mapstructure:"trivy-image"`
-}
-
-func (c Config) TimeUntilNextScan(cis *stasv1alpha1.ContainerImageScan) time.Duration {
-	if cis.Status.ObservedGeneration != cis.Generation || cis.Status.LastScanTime.IsZero() {
-		return 0
-	}
-
-	return time.Until(cis.Status.LastScanTime.Add(c.ScanInterval))
 }

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -49,12 +49,15 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, staserrors.Ignore(err, apierrors.IsNotFound)
 		}
 
+		var err error
+
 		timeUntilNextScan := r.TimeUntilNextScan(cis)
-		if timeUntilNextScan > 0 {
-			return ctrl.Result{RequeueAfter: timeUntilNextScan}, nil
+		if timeUntilNextScan <= 0 {
+			err = r.reconcile(ctx, cis)
+			timeUntilNextScan = r.ScanInterval
 		}
 
-		return ctrl.Result{}, r.reconcile(ctx, cis)
+		return ctrl.Result{RequeueAfter: timeUntilNextScan}, err
 	}
 
 	return controller.Reconcile(ctx, fn)

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -53,12 +53,10 @@ func cisRescanDue(scanInterval time.Duration) predicate.Predicate {
 		cis := object.(*stasv1alpha1.ContainerImageScan)
 		lastScanTime := cis.Status.LastScanTime
 		if lastScanTime.IsZero() {
-			return true
+			// Never scanned; other logic will trigger initial scan
+			return false
 		}
-		if time.Since(lastScanTime.Time) > scanInterval {
-			return true
-		}
-		return false
+		return time.Since(lastScanTime.Time) > scanInterval
 	})
 }
 

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -2,6 +2,7 @@ package stas
 
 import (
 	"regexp"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +46,20 @@ func podContainerStatusImagesChanged() predicate.Predicate {
 			return false
 		},
 	}
+}
+
+func cisRescanDue(scanInterval time.Duration) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		cis := object.(*stasv1alpha1.ContainerImageScan)
+		lastScanTime := cis.Status.LastScanTime
+		if lastScanTime.IsZero() {
+			return true
+		}
+		if time.Since(lastScanTime.Time) > scanInterval {
+			return true
+		}
+		return false
+	})
 }
 
 func ignoreCreationPredicate() predicate.Predicate {


### PR DESCRIPTION
We've had issues with the rescan logic as it seems like all/most CIS resources are reconciled when the operator is restarted. This is very unfortunate, especially in large clusters, resulting is a resource consumption burst.

@bendikp has performed some testing locally, and it seems like our logic for returning `RequeueAfter` when reconciling CIS must always be set. We assumed that we were "saved" by the default 10h `SyncPeriod`, but it seems like the sync events are filtered out - probably by the generation-changed predicate.

This PR tries to use predicates to highlight the two difference scan/rescan paths: scan/rescan because of CIS spec change (generation changed) OR rescan due (time based).