### PR TITLE
fix: rescan based on ticker

### DIFF
--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -3,7 +3,6 @@ package stas
 import (
 	"context"
 	"fmt"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +14,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
@@ -50,16 +52,7 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, staserrors.Ignore(err, apierrors.IsNotFound)
 		}
 
-		timeUntilNextScan := r.ScanInterval
-
-		if !cis.Status.LastScanTime.IsZero() {
-			d := time.Until(cis.Status.LastScanTime.Add(r.ScanInterval))
-			if d > 0 {
-				timeUntilNextScan = d
-			}
-		}
-
-		return ctrl.Result{RequeueAfter: timeUntilNextScan}, r.reconcile(ctx, cis)
+		return ctrl.Result{}, r.reconcile(ctx, cis)
 	}
 
 	return controller.Reconcile(ctx, fn)
@@ -76,13 +69,16 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		predicates = append(predicates, namespaceMatchRegexp(r.ScanNamespaceIncludeRegexp))
 	}
 
+	events := make(chan event.GenericEvent)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&stasv1alpha1.ContainerImageScan{},
 			builder.WithPredicates(
-				predicate.Or(predicate.GenerationChangedPredicate{}, cisRescanDue(r.ScanInterval)),
+				predicate.GenerationChangedPredicate{},
 				ignoreDeletionPredicate(),
 			)).
 		WithEventFilter(predicate.And(predicates...)).
+		Watches(&source.Channel{Source: events}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -32,7 +32,7 @@ type ContainerImageScanReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	config.Config
-	WatchChan chan event.GenericEvent
+	EventChan chan event.GenericEvent
 }
 
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans,verbs=get;list;watch;create;update;patch;delete
@@ -77,7 +77,7 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 				ignoreDeletionPredicate(),
 			)).
 		WithEventFilter(predicate.And(predicates...)).
-		Watches(&source.Channel{Source: r.WatchChan}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Channel{Source: r.EventChan}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -2,7 +2,6 @@ package stas
 
 import (
 	"regexp"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,18 +45,6 @@ func podContainerStatusImagesChanged() predicate.Predicate {
 			return false
 		},
 	}
-}
-
-func cisRescanDue(scanInterval time.Duration) predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(object client.Object) bool {
-		cis := object.(*stasv1alpha1.ContainerImageScan)
-		lastScanTime := cis.Status.LastScanTime
-		if lastScanTime.IsZero() {
-			// Never scanned; other logic will trigger initial scan
-			return false
-		}
-		return time.Since(lastScanTime.Time) > scanInterval
-	})
 }
 
 func ignoreCreationPredicate() predicate.Predicate {

--- a/internal/controller/stas/rescan.go
+++ b/internal/controller/stas/rescan.go
@@ -1,0 +1,38 @@
+package stas
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
+)
+
+type RescanTrigger struct {
+	client.Client
+	EventChan     chan event.GenericEvent
+	CheckInterval time.Duration
+}
+
+func (r *RescanTrigger) Start(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+
+	ticker := time.NewTicker(r.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			cisList := &stasv1alpha1.ContainerImageScanList{}
+			if err := r.List(ctx, cisList, client.InNamespace("")); err != nil {
+				log.Error(err, "failed to list CISes")
+				continue
+			}
+		}
+	}
+}

--- a/internal/controller/stas/rescan.go
+++ b/internal/controller/stas/rescan.go
@@ -35,16 +35,13 @@ func (r *RescanTrigger) Start(ctx context.Context) error {
 				log.Error(err, "failed to list CISes")
 				continue
 			}
-			for _, cis := range cisList.Items {
+
+			for i := range cisList.Items {
+				cis := cisList.Items[i]
+
 				lastScanTime := cis.Status.LastScanTime
-				if lastScanTime.IsZero() {
-					continue
-				}
-				if time.Since(lastScanTime.Time) > r.ScanInterval {
-					eventCis := &stasv1alpha1.ContainerImageScan{}
-					eventCis.Namespace = cis.Namespace
-					eventCis.Name = cis.Name
-					r.EventChan <- event.GenericEvent{Object: eventCis}
+				if !lastScanTime.IsZero() && time.Since(lastScanTime.Time) > r.ScanInterval {
+					r.EventChan <- event.GenericEvent{Object: &cis}
 				}
 			}
 		}

--- a/internal/controller/stas/rescan.go
+++ b/internal/controller/stas/rescan.go
@@ -9,10 +9,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
+	"github.com/statnett/image-scanner-operator/internal/config"
 )
 
 type RescanTrigger struct {
 	client.Client
+	config.Config
 	EventChan     chan event.GenericEvent
 	CheckInterval time.Duration
 }
@@ -32,6 +34,18 @@ func (r *RescanTrigger) Start(ctx context.Context) error {
 			if err := r.List(ctx, cisList, client.InNamespace("")); err != nil {
 				log.Error(err, "failed to list CISes")
 				continue
+			}
+			for _, cis := range cisList.Items {
+				lastScanTime := cis.Status.LastScanTime
+				if lastScanTime.IsZero() {
+					continue
+				}
+				if time.Since(lastScanTime.Time) > r.ScanInterval {
+					eventCis := &stasv1alpha1.ContainerImageScan{}
+					eventCis.Namespace = cis.Namespace
+					eventCis.Name = cis.Name
+					r.EventChan <- event.GenericEvent{Object: eventCis}
+				}
 			}
 		}
 	}

--- a/internal/controller/stas/scan_job_controller_test.go
+++ b/internal/controller/stas/scan_job_controller_test.go
@@ -191,8 +191,7 @@ func getContainerImageScanJob(cis *stasv1alpha1.ContainerImageScan) *batchv1.Job
 		client.InNamespace(scanJobNamespace),
 		client.MatchingLabels(map[string]string{stasv1alpha1.LabelStatnettControllerUID: string(cis.UID)}),
 	}
-	Expect(k8sClient.List(ctx, jobs, listOps...)).To(Succeed())
-	Expect(jobs.Items).To(HaveLen(1))
+	Eventually(komega.ObjectList(jobs, listOps...)).Should(HaveField("Items", HaveLen(1)))
 
 	return &jobs.Items[0]
 }

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/event"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -25,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -129,6 +128,7 @@ var _ = BeforeSuite(func() {
 	Expect(containerImageScanReconciler.SetupWithManager(k8sManager)).To(Succeed())
 	rescanTrigger := &RescanTrigger{
 		Client:        k8sManager.GetClient(),
+		Config:        config,
 		EventChan:     rescanEventChan,
 		CheckInterval: time.Second,
 	}

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -119,18 +119,18 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(podReconciler.SetupWithManager(k8sManager)).To(Succeed())
 
-	rescanEventChan := make(chan event.GenericEvent)
+	cisEventChan := make(chan event.GenericEvent)
 	containerImageScanReconciler := &ContainerImageScanReconciler{
 		Client:    k8sManager.GetClient(),
 		Scheme:    k8sScheme,
 		Config:    config,
-		WatchChan: rescanEventChan,
+		EventChan: cisEventChan,
 	}
 	Expect(containerImageScanReconciler.SetupWithManager(k8sManager)).To(Succeed())
 	rescanTrigger := &RescanTrigger{
 		Client:        k8sManager.GetClient(),
 		Config:        config,
-		EventChan:     rescanEventChan,
+		EventChan:     cisEventChan,
 		CheckInterval: time.Second,
 	}
 	Expect(k8sManager.Add(rescanTrigger)).To(Succeed())

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -104,6 +104,7 @@ var _ = BeforeSuite(func() {
 	config := config.Config{
 		ScanJobNamespace:      scanJobNamespace,
 		ScanJobServiceAccount: "image-scanner",
+		ScanInterval:          time.Hour,
 		TrivyImage:            "aquasecurity/trivy",
 	}
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/event"
-
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -21,6 +19,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
@@ -176,6 +175,7 @@ func (o Operator) Start(cfg config.Config) error {
 
 	if err := mgr.Add(&stas.RescanTrigger{
 		Client:        mgr.GetClient(),
+		Config:        cfg,
 		EventChan:     rescanEventChan,
 		CheckInterval: time.Minute,
 	}); err != nil {

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -166,7 +166,7 @@ func (o Operator) Start(cfg config.Config) error {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Config:    cfg,
-		WatchChan: rescanEventChan,
+		EventChan: rescanEventChan,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create %s controller: %w", "ContainerImageScan", err)
 	}


### PR DESCRIPTION
After many issues with the rescan logic, based on `RequeueAfter`, I propose to instead use a ticker to trigger a recurring job that submits events for rescans that are due. The tick interval is currently hardcoded to 1 minute, but we could also make it configurable.