### PR TITLE
chore: rename Trivy config param

### DIFF
--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -55,7 +55,7 @@ spec:
           env:
             - name: HOME
               value: /tmp
-            - name: TRIVY_SECURITY_CHECKS
+            - name: TRIVY_SCANNERS
               value: vuln
             - name: TRIVY_CACHE_DIR
               value: /tmp

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -186,7 +186,7 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	}
 	container.Env = []corev1.EnvVar{
 		{Name: "HOME", Value: TempVolumeMountPath},
-		{Name: "TRIVY_SECURITY_CHECKS", Value: "vuln"},
+		{Name: "TRIVY_SCANNERS", Value: "vuln"},
 		{Name: "TRIVY_CACHE_DIR", Value: TempVolumeMountPath},
 		{Name: "TRIVY_QUIET", Value: "true"},
 		{Name: "TRIVY_FORMAT", Value: "template"},


### PR DESCRIPTION
Renamed upstream: https://github.com/aquasecurity/trivy/pull/3467