### PR TITLE
fix!: introduce mitchellh/hashstructure for hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/distribution/distribution v2.8.1+incompatible
 	github.com/go-logr/logr v1.2.3
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -14,7 +14,7 @@ metadata:
     workload.statnett.no/name: echo
     workload.statnett.no/namespace: replica-set
   namespace: image-scanner-jobs
-  name: echo-6bdfc76c56-8ae43-b63f8
+  name: echo-6bdfc76c56-8ae43-738e6
 spec:
   activeDeadlineSeconds: 3600 # 1 hour
   backoffLimit: 0

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -153,27 +153,27 @@ var _ = Describe("Naming ContainerImageScan", func() {
 		}
 		containerName = "app"
 		img = stasv1alpha1.Image{Name: "img-name", Digest: "img-digest"}
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-22073"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-88c48"))
 	})
 
 	It("should contain controller name", func() {
 		ctrl.SetName("other-workload")
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-other-workload-app-22073"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-other-workload-app-88c48"))
 	})
 
 	It("should be a function of image name", func() {
 		img.Name = "other-img"
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-ad649"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-91ac0"))
 	})
 
 	It("should be a function of image digest", func() {
 		img.Digest = "other-digest"
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-3d4f2"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-app-faf6e"))
 	})
 
 	It("should contain container name", func() {
 		containerName = "foo"
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-foo-22073"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("application-workload-foo-88c48"))
 	})
 
 	It("should contain controller kind", func() {
@@ -185,7 +185,7 @@ var _ = Describe("Naming ContainerImageScan", func() {
 				Name: ctrl.GetName(),
 			},
 		}
-		Expect(imageScanName(ctrl, containerName, img)).To(Equal("deployment-workload-app-22073"))
+		Expect(imageScanName(ctrl, containerName, img)).To(Equal("deployment-workload-app-88c48"))
 	})
 
 	It("should shorten controller name part", func() {
@@ -193,10 +193,11 @@ var _ = Describe("Naming ContainerImageScan", func() {
 		Expect(longName).To(HaveLen(KubernetesNameMaxLength))
 
 		ctrl.SetName(longName)
-		cisName := imageScanName(ctrl, containerName, img)
+		cisName, err := imageScanName(ctrl, containerName, img)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(cisName).To(HaveLen(KubernetesNameMaxLength))
 		// Assert contains image short sha part
-		Expect(cisName).To(ContainSubstring("-22073"))
+		Expect(cisName).To(ContainSubstring("-88c48"))
 	})
 })
 

--- a/internal/hash/strings.go
+++ b/internal/hash/strings.go
@@ -1,15 +1,16 @@
 package hash
 
 import (
-	"crypto/md5" //#nosec G501 -- Weak cryptographic primitive only used for hashing
 	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
 )
 
-func NewString(objs ...interface{}) string {
-	digester := md5.New() //#nosec G401 -- Weak cryptographic primitive only used for hashing
-	for _, v := range objs {
-		digester.Write([]byte(fmt.Sprintf("%s", v)))
+func NewString(objs ...interface{}) (string, error) {
+	hash, err := hashstructure.Hash(objs, hashstructure.FormatV2, nil)
+	if err != nil {
+		return "", err
 	}
 
-	return fmt.Sprintf("%x", digester.Sum(nil))
+	return fmt.Sprintf("%x", hash), nil
 }

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -66,7 +66,12 @@ func (f *filesystemScanJobBuilder) ForCIS(cis *stasv1alpha1.ContainerImageScan) 
 	}
 
 	job.Namespace = f.ScanJobNamespace
-	job.Name, _ = scanJobName(cis)
+
+	job.Name, err = scanJobName(cis)
+	if err != nil {
+		return nil, err
+	}
+
 	job.Labels = map[string]string{
 		stasv1alpha1.LabelK8sAppName:                  stasv1alpha1.AppNameTrivy,
 		stasv1alpha1.LabelK8SAppManagedBy:             stasv1alpha1.AppNameImageScanner,

--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-vuln-app-app-eccf8
+  name: deployment-vuln-app-app-d7f94
 spec:
   digest: 'sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af'
   name: docker.io/kennship/http-echo

--- a/test/e2e/scenario/vulnerability-overflow/00-errors.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-errors.yaml
@@ -2,6 +2,6 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-vuln-app-app-eccf8
+  name: deployment-vuln-app-app-d7f94
 status:
   conditions: []

--- a/test/e2e/workload-scan/scan-cron-job/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: cronjob-echo-app-f24e5
+  name: cronjob-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: cronjob-echo-app-f24e5
+  name: cronjob-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-daemon-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: daemonset-echo-app-f24e5
+  name: daemonset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: daemonset-echo-app-f24e5
+  name: daemonset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-deployment/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-deployment/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-echo-app-f24e5
+  name: deployment-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-deployment/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-deployment/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-echo-app-f24e5
+  name: deployment-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-job/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-job/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: job-echo-app-f24e5
+  name: job-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-job/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: job-echo-app-f24e5
+  name: job-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-pod/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-pod/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: pod-echo-app-f24e5
+  name: pod-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-pod/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-pod/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: pod-echo-app-f24e5
+  name: pod-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-replica-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: replicaset-echo-app-f24e5
+  name: replicaset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: replicaset-echo-app-f24e5
+  name: replicaset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-stateful-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: statefulset-echo-app-f24e5
+  name: statefulset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged

--- a/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: statefulset-echo-app-f24e5
+  name: statefulset-echo-app-94a2e
 spec:
   digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
   name: docker.io/nginxinc/nginx-unprivileged


### PR DESCRIPTION
It seems like we are having an issue with scan job names not being idempotent in some cases. Attempting to replace our custom hash function with mitchellh/hashstructure.

BREAKING CHANGE: This will result in new CIS names that will appear as duplicates. It is advised to reinstall the operator on upgrade.
