### PR TITLE
fix: use last scan job UID instead of name

### DIFF
--- a/api/stas/v1alpha1/containerimagescan_types.go
+++ b/api/stas/v1alpha1/containerimagescan_types.go
@@ -5,6 +5,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
@@ -91,10 +92,10 @@ type ContainerImageScanSpec struct {
 type ContainerImageScanStatus struct {
 	// ObservedGeneration is the generation observed by the image scanner operator.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// LastScanJobUID is the UID of the scan job that last updated the status.
+	LastScanJobUID types.UID `json:"lastScanJobUID,omitempty"`
 	// LastScanTime is the timestamp for the last attempt to scan the image.
 	LastScanTime *metav1.Time `json:"lastScanTime,omitempty"`
-	// LastScanJobName is the name of the scan job that last (successfully) updated the status.
-	LastScanJobName string `json:"lastScanJobName,omitempty"`
 	// LastSuccessfulScanTime is the timestamp for the last successful scan of the image.
 	LastSuccessfulScanTime *metav1.Time `json:"lastSuccessfulScanTime,omitempty"`
 	// Conditions represent the latest available observations of an object's state.

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -170,9 +170,9 @@ spec:
                   - type
                   type: object
                 type: array
-              lastScanJobName:
-                description: LastScanJobName is the name of the scan job that last
-                  (successfully) updated the status.
+              lastScanJobUID:
+                description: LastScanJobUID is the UID of the scan job that last updated
+                  the status.
                 type: string
               lastScanTime:
                 description: LastScanTime is the timestamp for the last attempt to

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -70,7 +70,7 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batch
 			Type:    string(kstatus.ConditionStalled),
 			Status:  metav1.ConditionTrue,
 			Reason:  stasv1alpha1.ReasonScanReportDecodeError,
-			Message: fmt.Sprintf("error decoding scan report JSON from job '%s': %s", job, err),
+			Message: fmt.Sprintf("error decoding scan report JSON from job '%s': %s", job.Name, err),
 		}
 		meta.SetStatusCondition(&cis.Status.Conditions, condition)
 		meta.RemoveStatusCondition(&cis.Status.Conditions, string(kstatus.ConditionReconciling))

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -55,7 +55,7 @@ func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r.reconcile())
 }
 
-func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, jobName string, log io.Reader, cis *stasv1alpha1.ContainerImageScan) error {
+func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batchv1.Job, log io.Reader, cis *stasv1alpha1.ContainerImageScan) error {
 	var (
 		cleanCis        = cis.DeepCopy()
 		vulnerabilities []stasv1alpha1.Vulnerability
@@ -70,12 +70,12 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, jobName st
 			Type:    string(kstatus.ConditionStalled),
 			Status:  metav1.ConditionTrue,
 			Reason:  stasv1alpha1.ReasonScanReportDecodeError,
-			Message: fmt.Sprintf("error decoding scan report JSON from job '%s': %s", jobName, err),
+			Message: fmt.Sprintf("error decoding scan report JSON from job '%s': %s", job, err),
 		}
 		meta.SetStatusCondition(&cis.Status.Conditions, condition)
 		meta.RemoveStatusCondition(&cis.Status.Conditions, string(kstatus.ConditionReconciling))
 		cis.Status.LastScanTime = &now
-		cis.Status.LastScanJobName = jobName
+		cis.Status.LastScanJobUID = job.UID
 		err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
 		logf.FromContext(ctx).V(1).Info("Patched CIS status", "reason", condition.Reason, "error", err)
 
@@ -97,7 +97,7 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, jobName st
 	// Clear any conditions since we now have a successful scan report
 	cis.Status.Conditions = nil
 	cis.Status.LastScanTime = &now
-	cis.Status.LastScanJobName = jobName
+	cis.Status.LastScanJobUID = job.UID
 	cis.Status.LastSuccessfulScanTime = &now
 
 	err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
@@ -113,7 +113,7 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, jobName st
 		meta.SetStatusCondition(&cis.Status.Conditions, condition)
 		meta.RemoveStatusCondition(&cis.Status.Conditions, string(kstatus.ConditionReconciling))
 		cis.Status.LastScanTime = &now
-		cis.Status.LastScanJobName = jobName
+		cis.Status.LastScanJobUID = job.UID
 		err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
 		logf.FromContext(ctx).V(1).Info("Patched CIS status", "reason", condition.Reason, "error", err)
 	}
@@ -127,7 +127,7 @@ func isResourceTooLargeError(err error) bool {
 			strings.Contains(err.Error(), "request is too large"))
 }
 
-func (r *ScanJobReconciler) reconcileFailedJob(ctx context.Context, jobName string, log io.Reader, cis *stasv1alpha1.ContainerImageScan) error {
+func (r *ScanJobReconciler) reconcileFailedJob(ctx context.Context, job *batchv1.Job, log io.Reader, cis *stasv1alpha1.ContainerImageScan) error {
 	cleanCis := cis.DeepCopy()
 
 	logBytes, err := io.ReadAll(log)
@@ -146,7 +146,7 @@ func (r *ScanJobReconciler) reconcileFailedJob(ctx context.Context, jobName stri
 
 	now := metav1.Now()
 	cis.Status.LastScanTime = &now
-	cis.Status.LastScanJobName = jobName
+	cis.Status.LastScanJobUID = job.UID
 
 	return r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
 }
@@ -192,7 +192,7 @@ func (r *ScanJobReconciler) reconcileJob(ctx context.Context, job *batchv1.Job) 
 
 	cis := &cisList.Items[0]
 
-	if job.Name == cis.Status.LastScanJobName {
+	if job.UID == cis.Status.LastScanJobUID {
 		// We already reconciled this job; no point doing it again
 		return nil
 	}
@@ -202,7 +202,7 @@ func (r *ScanJobReconciler) reconcileJob(ctx context.Context, job *batchv1.Job) 
 		switch {
 		case staserrors.IsJobPodNotFound(err), staserrors.IsScanJobContainerWaiting(err):
 			logf.FromContext(ctx).V(1).Info("Error while fetching logs", "error", err)
-			return r.reconcileFailedJob(ctx, job.Name, strings.NewReader(err.Error()), cis)
+			return r.reconcileFailedJob(ctx, job, strings.NewReader(err.Error()), cis)
 		default:
 			return err
 		}
@@ -217,10 +217,10 @@ func (r *ScanJobReconciler) reconcileJob(ctx context.Context, job *batchv1.Job) 
 
 	if job.Status.Succeeded > 0 {
 		logf.FromContext(ctx).V(1).Info("Patching CIS status", "status", "Succeeded")
-		return r.reconcileCompleteJob(ctx, job.Name, logs, cis)
+		return r.reconcileCompleteJob(ctx, job, logs, cis)
 	} else {
 		logf.FromContext(ctx).V(1).Info("Patching CIS status", "status", "Failed")
-		return r.reconcileFailedJob(ctx, job.Name, logs, cis)
+		return r.reconcileFailedJob(ctx, job, logs, cis)
 	}
 }
 

--- a/internal/controller/stas/scan_job_controller_test.go
+++ b/internal/controller/stas/scan_job_controller_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Scan Job controller", func() {
 			// Wait for Job to get reconciled
 			Eventually(komega.Object(cis), timeout, interval).Should(HaveField("Status.LastScanTime", Not(BeZero())))
 			Expect(cis.Status.LastSuccessfulScanTime).To(Not(BeZero()))
-			Expect(cis.Status.LastScanJobName).To(Equal(scanJob.Name))
+			Expect(cis.Status.LastScanJobUID).To(Equal(scanJob.UID))
 			// Check no conditions
 			Expect(cis.Status.Conditions).To(BeEmpty())
 			// Check scan results available
@@ -96,7 +96,7 @@ var _ = Describe("Scan Job controller", func() {
 				// Wait for Job to get reconciled
 				Eventually(komega.Object(cis), timeout, interval).Should(HaveField("Status.LastScanTime", Not(BeZero())))
 				Expect(cis.Status.LastSuccessfulScanTime).To(BeZero())
-				Expect(cis.Status.LastScanJobName).To(Equal(scanJob.Name))
+				Expect(cis.Status.LastScanJobUID).To(Equal(scanJob.UID))
 				// Check conditions
 				Expect(cis.Status.Conditions).To(HaveLen(1))
 				condition := cis.Status.Conditions[0]
@@ -129,7 +129,7 @@ var _ = Describe("Scan Job controller", func() {
 				// Wait for Job to get reconciled
 				Eventually(komega.Object(cis), timeout, interval).Should(HaveField("Status.LastScanTime", Not(BeZero())))
 				Expect(cis.Status.LastSuccessfulScanTime).To(BeZero())
-				Expect(cis.Status.LastScanJobName).To(Equal(scanJob.Name))
+				Expect(cis.Status.LastScanJobUID).To(Equal(scanJob.UID))
 				// Check conditions
 				Expect(cis.Status.Conditions).To(HaveLen(1))
 				condition := cis.Status.Conditions[0]
@@ -163,7 +163,7 @@ var _ = Describe("Scan Job controller", func() {
 			// Wait for Job to get reconciled
 			Eventually(komega.Object(cis), timeout, interval).Should(HaveField("Status.LastScanTime", Not(BeZero())))
 			Expect(cis.Status.LastSuccessfulScanTime).To(BeZero())
-			Expect(cis.Status.LastScanJobName).To(Equal(scanJob.Name))
+			Expect(cis.Status.LastScanJobUID).To(Equal(scanJob.UID))
 			// Check conditions
 			Expect(cis.Status.Conditions).To(HaveLen(1))
 			condition := cis.Status.Conditions[0]


### PR DESCRIPTION
After we moved away from using `generateName` for scan jobs, the rescan job gets the same name as the scan job. This results in the CIS not being updated from new scan jobs. This PR suggests to use the UID of the scan job instead of the name.

**Maybe we should consider this change as breaking?**