### PR TITLE
fix: max active scan job limit

### DIFF
--- a/config/image-scanner-jobs/resource_quota.yaml
+++ b/config/image-scanner-jobs/resource_quota.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   hard:
     limits.cpu: '4'
-    limits.memory: 32Gi
-    requests.cpu: '2'
-    requests.memory: 16Gi
+    limits.memory: 4Gi
+    requests.cpu: 800m
+    requests.memory: 800M

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,4 +15,5 @@ type Config struct {
 	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
 	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
 	TrivyImage                 string         `mapstructure:"trivy-image"`
+	ActiveScanJobLimit         int            `mapstructure:"active-scan-job-limit"`
 }

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -77,7 +77,7 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 func (r *ContainerImageScanReconciler) activeScanJobCount(ctx context.Context) (int, error) {
 	listOps := []client.ListOption{
 		client.InNamespace(r.ScanJobNamespace),
-		client.MatchingFields{indexJobStatus: jobStatusNotFinished},
+		client.MatchingFields{indexJobCondition: jobNotFinished},
 	}
 
 	list := &batchv1.JobList{}

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -110,11 +110,11 @@ var cisVulnerabilityOverflow = predicate.NewPredicateFuncs(func(object client.Ob
 // It does not discriminate between successful and failed terminations.
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/utils.go#L24-L33
 func isJobFinished(j *batchv1.Job) bool {
-	s := jobStatus(j)
-	return s == batchv1.JobComplete || s == batchv1.JobFailed
+	c := jobCondition(j)
+	return c == batchv1.JobComplete || c == batchv1.JobFailed
 }
 
-func jobStatus(j *batchv1.Job) batchv1.JobConditionType {
+func jobCondition(j *batchv1.Job) batchv1.JobConditionType {
 	for _, c := range j.Status.Conditions {
 		if c.Status == corev1.ConditionTrue {
 			return c.Type

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -215,15 +215,15 @@ func (r *ScanJobReconciler) reconcileJob(ctx context.Context, job *batchv1.Job) 
 		}
 	}(logs)
 
-	switch js := jobStatus(job); js {
+	switch jc := jobCondition(job); jc {
 	case batchv1.JobComplete:
-		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobStatus", js)
+		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", jc)
 		return r.reconcileCompleteJob(ctx, job, logs, cis)
 	case batchv1.JobFailed:
-		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobStatus", js)
+		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", jc)
 		return r.reconcileFailedJob(ctx, job, logs, cis)
 	default:
-		return fmt.Errorf("I don't know how to handle job status %q", js)
+		return fmt.Errorf("I don't know how to handle job status %q", jc)
 	}
 }
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -59,6 +59,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
+	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}


### PR DESCRIPTION
While ResourceQuotas is a good safety guard, it does not seem to work well for limiting the workload scheduled by controllers. The number of events created by hitting the resource quota limit can be quite significant and not acceptable.

This PR adds a mechanism for limiting the number of jobs created by the operator - based on the current number of active scan jobs. The limit is configurable with a current default value of `8`. The suggested default is based on the current limitations in the configured resource quota and requests/limits on the scan job container. I'll suggest reviewing the overall configuration in a follow-up PR.