### PR TITLE
fix: request smaller PV for trivy server cache

### DIFF
--- a/config/trivy-server/stateful_set.yaml
+++ b/config/trivy-server/stateful_set.yaml
@@ -12,7 +12,7 @@ spec:
       spec:
         resources:
           requests:
-            storage: 5Gi
+            storage: 1Gi
         accessModes:
           - ReadWriteOnce
   template:


### PR DESCRIPTION
It seems like requesting 5Gi persistence for Trivy server by default seems way too much. We are using around 300MB in our clusters currently, and it does not seem to increase significantly.