### PR TITLE
chore: run scan jobs in "slow" mode in e2e-tests

### DIFF
--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -9,6 +9,11 @@ configMapGenerator:
     literals:
       # Only include kuttl namespace pattern to reduce resource waste running e2e tests
       - SCAN_NAMESPACE_INCLUDE_REGEXP=^kuttl-.*
+  - name: trivy-job-config
+    behavior: merge
+    literals:
+      # See if "slow" config can improve stability
+      - SLOW=true
 patches:
   # FIXME: Somehow sessionAffinity does not work when running e2e tests in some environments
   # Disable trivy server sessionAffinity; not really needed when running a single replica


### PR DESCRIPTION
I wonder if we should use the "slow" mode by default, and this PR tries it out for the e2e-tests.