### PR TITLE
ci: add manual trigger for clean GHCR workflow

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -3,6 +3,7 @@ name: Delete obsolete container images
 on:
   schedule:
     - cron: "0 1 * * *"  # every day at midnight
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
We are having issues with GHCR cleanup workflow. It currently runs only scheduled. This PR allows the workflow to be triggered manually.