### PR TITLE
build: don't use latest image tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     needs: verify-generated
     runs-on: ubuntu-latest
     env:
-      IMG: registry.dummy-domain.com/image-scanner/controller:latest
+      IMG: registry.dummy-domain.com/image-scanner/controller:dev
       IMG_FILE: operator-image.tar
       K3D_CLUSTER: image-scanner
       # renovate: datasource=github-tags depName=k3d-io/k3d

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= "registry.dummy-domain.com/image-scanner/controller:latest"
+IMG ?= "registry.dummy-domain.com/image-scanner/controller:dev"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.0
 # Namespace to install operator into

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -20,4 +20,4 @@ configMapGenerator:
 images:
   - name: controller
     newName: registry.dummy-domain.com/image-scanner/controller
-    newTag: latest
+    newTag: dev


### PR DESCRIPTION
I noticed a comment on https://microk8s.io/docs/registry-images:

> Note that containerd will not cache images with the latest tag so make sure you avoid it.

So this PR changes the build/CI image tag from `latest` to `dev`.