### PR TITLE
fix: ensure job pod is deleted when deleting scan job

### DIFF
--- a/internal/controller/stas/scan_job_backoff_pod_controller_test.go
+++ b/internal/controller/stas/scan_job_backoff_pod_controller_test.go
@@ -3,6 +3,7 @@ package stas
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"path"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -59,8 +60,8 @@ var _ = Describe("Scan Job BackOff Pod controller", func() {
 			Expect(condition.Reason).To(Equal("Error"))
 			Expect(condition.Message).To(Equal("Image not found"))
 
-			// Check that scan job is "deleted"
-			Eventually(komega.Object(scanJob)).Should(HaveField("ObjectMeta.DeletionTimestamp", Not(BeZero())))
+			// Check that scan job is deleted
+			Eventually(komega.Get(scanJob)).Should(WithTransform(errors.ReasonForError, Equal(metav1.StatusReasonNotFound)))
 		})
 	})
 })

--- a/internal/controller/stas/scan_job_backoff_pod_controller_test.go
+++ b/internal/controller/stas/scan_job_backoff_pod_controller_test.go
@@ -3,12 +3,12 @@ package stas
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"path"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -119,16 +119,17 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 				return ctrl.Result{}, fmt.Errorf("no container-state waiting found with reasons %q in pod %q", reasons, p.Name)
 			}
 
-			pc := metav1.GetControllerOf(p)
-			if pc == nil {
-				return ctrl.Result{}, fmt.Errorf("no owner found for pod %q", p.Name)
+			podController := metav1.GetControllerOf(p)
+			if podController == nil {
+				return ctrl.Result{}, fmt.Errorf("no controller found for pod %q", p.Name)
 			}
-			if pc.Kind != "Job" {
+
+			if podController.Kind != "Job" {
 				return ctrl.Result{}, nil
 			}
 
 			job := &batchv1.Job{}
-			if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: pc.Name}, job); err != nil {
+			if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: podController.Name}, job); err != nil {
 				return ctrl.Result{}, staserrors.Ignore(err, apierrors.IsNotFound)
 			}
 

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -120,6 +120,9 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 			}
 
 			pc := metav1.GetControllerOf(p)
+			if pc == nil {
+				return ctrl.Result{}, fmt.Errorf("no owner found for pod %q", p.Name)
+			}
 			if pc.Kind != "Job" {
 				return ctrl.Result{}, nil
 			}
@@ -137,7 +140,7 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 }
 
 func (r *ScanJobReconciler) reconcileBackOffJob(ctx context.Context, job *batchv1.Job, errMsg string) error {
-	if err := r.Delete(ctx, job); err != nil {
+	if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We must ensure scan job pod is deleted when deleting scan job. Currently the pod seems to be orphaned causing panic on next reconcile. Also adding a safety-guard if this happens again, to get a meaningful error - instead of the current panic.