### PR TITLE
fix: add debug logging for container state waiting

### DIFF
--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -116,7 +116,8 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 					reasons = append(reasons, k)
 				}
 
-				return ctrl.Result{}, fmt.Errorf("no container-state waiting found with reasons %q in pod %q", reasons, p.Name)
+				return ctrl.Result{}, fmt.Errorf("no waiting state found with reasons %q in pod %q with container statuses %+v",
+					reasons, p.Name, p.Status.ContainerStatuses)
 			}
 
 			podController := metav1.GetControllerOf(p)


### PR DESCRIPTION
We are struggling with reconciliation errors for unsuccessful scan jobs:

```json
{"level":"error","ts":"2023-02-26T06:15:31.187Z","msg":"Reconciler error","controller":"backOffScanJobPod","namespace":"image-scanner-jobs","name":"<pod-name>","reconcileID":"a5540570-c9c8-4a66-8cd7-8927b891c198","error":"no container-state waiting found with reasons [\"ImagePullBackOff\" \"ErrImagePull\"] in pod \""<pod-name>","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:235"}
```

This PR adds some more debug to get more details on the pods "in flight".