### PR TITLE
fix: requeue event when no container state waiting found

### DIFF
--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -111,13 +111,14 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 			}
 
 			if stateWaiting == nil {
-				reasons := make([]string, 0, len(backoffContainerStateReasons))
+				expectedReasons := make([]string, 0, len(backoffContainerStateReasons))
 				for k := range backoffContainerStateReasons {
-					reasons = append(reasons, k)
+					expectedReasons = append(expectedReasons, k)
 				}
 
-				return ctrl.Result{}, fmt.Errorf("no waiting state found with reasons %q in pod %q with container statuses %+v",
-					reasons, p.Name, p.Status.ContainerStatuses)
+				logf.FromContext(ctx).V(1).Info("no waiting state found", "expectedReasons", expectedReasons)
+				// Pod (in controller cache) has not yet reached waiting state. Requeue event
+				return ctrl.Result{Requeue: true}, nil
 			}
 
 			podController := metav1.GetControllerOf(p)


### PR DESCRIPTION
This is a follow-up to https://github.com/statnett/image-scanner-operator/pull/236. After installing the latest release in our cluster, we observe the following improved logging:

```json
{"level":"error","ts":"2023-02-27T14:43:13.854Z","msg":"Reconciler error","controller":"backOffScanJobPod","namespace":"image-scanner-jobs","name":"<pod-name>","reconcileID":"e7f07c11-3bb4-46eb-9827-268e51d5c3d7","error":"no waiting state found with reasons [\"ImagePullBackOff\" \"ErrImagePull\"] in pod \"<pod-name>\" with container statuses [{Name:scan-image State:{Waiting:&ContainerStateWaiting{Reason:PodInitializing,Message:,} Running:nil Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:artifactory.statnett.no/fifty-lab-docker-dev-local/mfrr-bid-collector@sha256:bbbe228164fe4fa8459219b7ab0580009734481ae8ce76bb1a5dc7cc7d7ad1de ImageID: ContainerID: Started:0xc03a091885}]","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:235"}
```

And as I suspected, the pod has not yet reached the waiting state **in controller cache**. This PR just requeues the event if this happens. The cache should be eventually consistent.