### PR TITLE
fix: tighten cluster-wide RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,13 +16,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/log
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - replicationcontrollers
   verbs:
   - get
@@ -73,16 +66,6 @@ rules:
   resources:
   - jobs
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
   - get
   - list
   - watch
@@ -112,3 +95,44 @@ rules:
   - get
   - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: image-scanner-jobs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -109,7 +109,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
-  namespace: image-scanner-jobs
+  namespace: image-scanner
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - stas.statnett.no
   resources:
   - containerimagescans
@@ -125,14 +133,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
   - get
   - list
   - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -17,3 +17,17 @@ subjects:
   - kind: ServiceAccount
     name: controller-manager
     namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+  namespace: image-scanner-jobs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
-  namespace: image-scanner-jobs
+  namespace: image-scanner
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -22,7 +22,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
-  namespace: image-scanner
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -22,6 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
+  namespace: image-scanner
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -39,7 +39,7 @@ type ContainerImageScanReconciler struct {
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans/finalizers,verbs=update
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete,namespace=image-scanner
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -39,7 +39,7 @@ type ContainerImageScanReconciler struct {
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans/finalizers,verbs=update
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete,namespace=image-scanner-jobs
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -47,9 +47,9 @@ type ScanJobReconciler struct {
 	pod.LogsReader
 }
 
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch,namespace=image-scanner-jobs
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner-jobs
-//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch,namespace=image-scanner
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -50,7 +50,7 @@ type ScanJobReconciler struct {
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch,namespace=image-scanner-jobs
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner-jobs
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner-jobs
-//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -47,10 +47,10 @@ type ScanJobReconciler struct {
 	pod.LogsReader
 }
 
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list
-//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner-jobs
+//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch,namespace=image-scanner-jobs
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -69,6 +69,7 @@ func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("backOffScanJobPod").
+		WithEventFilter(inNamespacePredicate(r.ScanJobNamespace)).
 		Watches(
 			&source.Kind{Type: &eventsv1.Event{}},
 			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
@@ -81,7 +82,6 @@ func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 			}),
 			builder.WithPredicates(
-				inNamespacePredicate(r.ScanJobNamespace),
 				eventRegardingKind("Pod"),
 				eventReason("BackOff"),
 			),


### PR DESCRIPTION
This PR replaces some of the cluster-wide RBAC with namespace RBAC in image-scanner namespace. We should always attempt to grant least-privilege permissions...