### PR TITLE
ci: fix release-please permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
-permissions: # added using https://github.com/step-security/secure-workflows
-  contents: read
+permissions:
+  contents: write # for google-github-actions/release-please-action to create release commit
+  pull-requests: write # for google-github-actions/release-please-action to create release PR
 jobs:
   release-please:
-    permissions:
-      contents: write # for google-github-actions/release-please-action to create release commit
-      pull-requests: write # for google-github-actions/release-please-action to create release PR
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Seems like the permissions must be added to the workflow. Job permissions do not seem sufficient. Verified fixing issue here: https://github.com/statnett/controller-runtime-viper/pull/115