### PR TITLE
revert: "fix: never retry scan job (#194)"

### DIFF
--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -17,7 +17,7 @@ metadata:
   name: echo-6bdfc76c56-8ae43-738e6
 spec:
   activeDeadlineSeconds: 3600 # 1 hour
-  backoffLimit: 0
+  backoffLimit: 3
   completionMode: NonIndexed
   completions: 1
   parallelism: 1
@@ -117,7 +117,7 @@ spec:
           volumeMounts:
             - mountPath: /var/run/image-scanner
               name: image-scanner
-      restartPolicy: Never
+      restartPolicy: OnFailure
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: image-scanner

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -142,7 +142,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	job.Spec.Parallelism = pointer.Int32(1)
 	job.Spec.Completions = pointer.Int32(1)
 	job.Spec.ActiveDeadlineSeconds = pointer.Int64(int64(3600))
-	job.Spec.BackoffLimit = pointer.Int32(0)
+	job.Spec.BackoffLimit = pointer.Int32(3)
 	job.Spec.TTLSecondsAfterFinished = pointer.Int32(7200)
 	job.Spec.Template.Spec.ServiceAccountName = f.ScanJobServiceAccount
 
@@ -169,7 +169,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	}
 
 	job.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
-	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 
 	return job, nil
 }


### PR DESCRIPTION
This reverts commit 0198fc1da0b64ccbf327d4e739cbd3c8fd23648a.

We are struggling with fragile e2e-tests, so we should re-introduce the scan job retries. The problem seems to be in Trivy, and the Trivy-maintainers do not seem to have any appetite to fix it.
