### PR TITLE
revert: "ci(test): use ginkgo to run go tests (#183)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version-file: go.mod
-          cache: true
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,7 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version-file: go.mod
-      - name: Install ginkgo
-        run: |
-          command -v ginkgo || go install -v github.com/onsi/ginkgo/v2/ginkgo@${{ env.GINKGO_VERSION }}
-        env:
-          GINKGO_VERSION: v2.8.0
+          cache: true
       - run: make test
         env:
           KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,6 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 1. Run `make test` to run both unit and integrations (envtest) tests. [envtest][envtest] runs etcd and apiserver
    locally without the need for a real Kubernetes cluster. It helps to test the controller and the reconciliation logic.
-   Note: Requires `ginkgo` binary to run the tests:
-
-   ```shell
-   go install -v github.com/onsi/ginkgo/v2/ginkgo@latest
-   ```
 
 1. Optionally, run the e2e-tests. The e2e tests assumes that you have a working kubernetes cluster (e.g. kind or k3s cluster)
    and `KUBECONFIG` environment variable is pointing to that cluster configuration file. For example:

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v --trace --repeat 3 --race ./... -coverprofile cover.out
+test: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./... -coverprofile cover.out
 
 test-reports: test ## Run tests and generate reports (no reports for now)
 
@@ -167,13 +167,11 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOIMPORTS ?= $(LOCALBIN)/goimports
-GINKGO ?= $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.11.1
 GOIMPORTS_VERSION ?= v0.3.0
-GINKGO_VERSION ?= v2.8.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -199,15 +197,6 @@ $(ENVTEST): $(LOCALBIN)
 goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
 $(GOIMPORTS):
 	test -s $(LOCALBIN)/goimports || GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
-
-.PHONY: ginkgo
-ginkgo: $(GINKGO) ## Download ginkgo locally if necessary. If wrong version is installed, it will be removed before downloading.
-$(GINKGO): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/ginkgo && ! $(LOCALBIN)/ginkgo version | grep -q $(GINKGO_VERSION); then \
-		echo "$(LOCALBIN)/ginkgo version is not expected $(GINKGO_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/ginkgo; \
-	fi
-	test -s $(LOCALBIN)/ginkgo || GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
 ##@ End-to-end (e2e) Testing
 


### PR DESCRIPTION
This reverts commits ea202d0e7062a8ffe520cb56236199846afa7da9 fe6d901a.

I think ginkgo slows down the build, both locally and in CI, and I still cannot see the benefit of using it instead of the standard `go test`.