### PR TITLE
ci(e2e): remove debug logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,15 +117,12 @@ jobs:
           tags: ${{ env.IMG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - run: |
-          mkdir /tmp/pod-logs
       - uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           cluster-name: ${{ env.K3D_CLUSTER }}
           k3d-version: ${{ env.K3D_VERSION }}
           args: >-
             --config=test/e2e-config/k3d-config.yml
-            --volume=/tmp/pod-logs:/var/log/pods
       - run: |
           kubectl cluster-info
           kubectl version --output=yaml
@@ -140,14 +137,3 @@ jobs:
           cache: enable
       - run: |
           make e2e-test
-      - if: ${{ failure() }}
-        # Copy files from volume and update permissions to avoid permission denied
-        run: |
-          kubectl get pods -n image-scanner -l workload.statnett.no/name=vuln-app -o yaml
-          sudo cp -r /tmp/pod-logs/ pod-logs/
-          sudo chmod -R a+rw pod-logs/
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        if: ${{ failure() }}
-        with:
-          name: pod-logs
-          path: pod-logs/


### PR DESCRIPTION
I think now know what's the cause of the fragile e2e tests, and in order to speed up the workflow I suggest removing the extensive logging introduced to dig into this.