### PR TITLE
fix: improve logging when CIS .status.conditions patch fails

### DIFF
--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -176,8 +176,11 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batch
 		meta.RemoveStatusCondition(&cis.Status.Conditions, string(kstatus.ConditionReconciling))
 		cis.Status.LastScanTime = &now
 		cis.Status.LastScanJobUID = job.UID
+
 		err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
-		logf.FromContext(ctx).V(1).Info("Patched CIS status", "reason", condition.Reason, "error", err)
+		if err != nil {
+			logf.FromContext(ctx).Error(err, "when patching status", "condition", condition)
+		}
 
 		return err
 	}
@@ -214,8 +217,11 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batch
 		meta.RemoveStatusCondition(&cis.Status.Conditions, string(kstatus.ConditionReconciling))
 		cis.Status.LastScanTime = &now
 		cis.Status.LastScanJobUID = job.UID
+
 		err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
-		logf.FromContext(ctx).V(1).Info("Patched CIS status", "reason", condition.Reason, "error", err)
+		if err != nil {
+			logf.FromContext(ctx).Error(err, "when patching status", "condition", condition)
+		}
 	}
 
 	return err
@@ -248,7 +254,12 @@ func (r *ScanJobReconciler) reconcileFailedJob(ctx context.Context, job *batchv1
 	cis.Status.LastScanTime = &now
 	cis.Status.LastScanJobUID = job.UID
 
-	return r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
+	err = r.Status().Patch(ctx, cis, client.MergeFrom(cleanCis))
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "when patching status", "condition", condition)
+	}
+
+	return err
 }
 
 func (r *ScanJobReconciler) reconcile() reconcile.Func {


### PR DESCRIPTION
We observe some new kinds of errors in our clusters. Example:

````json
{"level":"error","ts":"2023-05-02T05:48:57.094Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"application-session-orchestrator-app-2788e-6c040","namespace":"image-scanner"},"namespace":"image-scanner","name":"application-session-orchestrator-app-2788e-6c040","reconcileID":"152a0bc7-0487-4cbc-a93f-7862a359b878","error":"ContainerImageScan.stas.statnett.no \"application-session-orchestrator-app-2788e\" is invalid: status.conditions[0].message: Too long: may not be longer than 32768","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235"}
````

The error indicates an error message too long to fit in the API. This PR adds additional logging if this happens, as we need more information to analyze this issue further.