### PR TITLE
fix: don't consider evicted pods when looking for scan job pods

### DIFF
--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -364,12 +364,8 @@ func (r *ScanJobReconciler) getScanJobLogs(ctx context.Context, job *batchv1.Job
 		}
 	}
 
-	switch len(pods) {
-	case 0:
-		return nil, staserrors.NewNotFound(fmt.Sprintf("no pods found for job %q", job.Name))
-	case 1:
-	default:
-		return nil, fmt.Errorf("expected number of job pods to be 1, got %d ", len(pods))
+	if len(pods) != 1 {
+		return nil, fmt.Errorf("expected number of job pods to be 1, got %d", len(pods))
 	}
 
 	jobPod := pods[0]

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -357,6 +357,7 @@ func (r *ScanJobReconciler) getScanJobLogs(ctx context.Context, job *batchv1.Job
 	}
 
 	var pods []corev1.Pod
+
 	for _, p := range podList.Items {
 		if p.Status.Reason != "Evicted" {
 			pods = append(pods, p)


### PR DESCRIPTION
During an upgrade of our cluster, we got a couple of evicted scan job pods. These resulted in errors in our logs: `expected number of job pods to be 1, got X`. This MR fixes this by ignoring evicted pods when searching for scan job pods.