### PR TITLE
fix: revert change in scan job pod error handling

### DIFF
--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -364,8 +364,12 @@ func (r *ScanJobReconciler) getScanJobLogs(ctx context.Context, job *batchv1.Job
 		}
 	}
 
-	if len(pods) != 1 {
-		return nil, fmt.Errorf("expected number of job pods to be 1, got %d", len(pods))
+	switch len(pods) {
+	case 0:
+		return nil, staserrors.NewNotFound(fmt.Sprintf("no pods found for job %q", job.Name))
+	case 1:
+	default:
+		return nil, fmt.Errorf("expected number of job pods to be 1, got %d ", len(pods))
 	}
 
 	jobPod := pods[0]


### PR DESCRIPTION
The error handling for counting scan job pod was non-intentionally changed in https://github.com/statnett/image-scanner-operator/pull/369. This PR reverts these changes.