### PR TITLE
ci: don't run workflow requiring secrets in forks

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 jobs:
   build-push-image:
-    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
+    if: ${{ github.repository == 'statnett/image-scanner-operator' }}
     permissions:
       contents: read # for actions/checkout to fetch code
       packages: write # for docker/build-push-action to push images

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,6 +13,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 jobs:
   build-push-image:
+    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
     permissions:
       contents: read # for actions/checkout to fetch code
       packages: write # for docker/build-push-action to push images

--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   clean-ghcr:
     name: Delete obsolete container images
+    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
     permissions:
       packages: write # for snok/container-retention-policy to delete images
     runs-on: ubuntu-latest

--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   clean-ghcr:
     name: Delete obsolete container images
-    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
+    if: ${{ github.repository == 'statnett/image-scanner-operator' }}
     permissions:
       packages: write # for snok/container-retention-policy to delete images
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write # for google-github-actions/release-please-action to create release PR
 jobs:
   release-please:
-    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
+    if: ${{ github.repository == 'statnett/image-scanner-operator' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ permissions:
   pull-requests: write # for google-github-actions/release-please-action to create release PR
 jobs:
   release-please:
+    if: ${{ github.repository == ‘statnett/image-scanner-operator’ }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
After resyncing the main branch in my fork, that triggered a workflow that will never work (in forks). GitHub has limited support for doing this, so the fix is a semi-hack inspired by https://github.com/orgs/community/discussions/26704.