### PR TITLE
fix: do relabeling after scraping

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   podMetricsEndpoints:
     - honorLabels: true
-      relabelings:
+      metricRelabelings:
         - sourceLabels:
             - namespace
           targetLabel: kubernetes_namespace


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
After https://github.com/statnett/image-scanner-operator/pull/442 the `kubernetes_name` label has missing since the `name` label isn't present before after scraping. Hence moving from `relabeling` (before scrape) to `metricRelabeling` (after scrape/before ingestion).