### PR TITLE
ci: allow users to trigger release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 permissions:
   contents: write # for google-github-actions/release-please-action to create release commit
   pull-requests: write # for google-github-actions/release-please-action to create release PR


### PR DESCRIPTION
There seems to be occasional problems with the release please workflow which makes the release PRs incomplete. This PR will allow users (maintainers) to trigger the workflow manually.