### PR TITLE
ci: add Renovate markers to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,11 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOIMPORTS ?= $(LOCALBIN)/goimports
 
 ## Tool Versions
+# renovate: datasource=repology depName=kustomize packageName=scoop/kustomize versioning=loose
 KUSTOMIZE_VERSION ?= v5.0.3
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
+# renovate: datasource=go depName=golang.org/x/tools/cmd/goimports
 GOIMPORTS_VERSION ?= v0.3.0
 
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ GOIMPORTS ?= $(LOCALBIN)/goimports
 KUSTOMIZE_VERSION ?= v5.0.3
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
-# renovate: datasource=go depName=golang.org/x/tools/cmd/goimports
+# renovate: datasource=go depName=golang.org/x/tools/cmd/goimports packageName=golang.org/x/tools
 GOIMPORTS_VERSION ?= v0.3.0
 
 .PHONY: kustomize


### PR DESCRIPTION
I noticed that dependencies in the Makefile are a bit outdated. Suggesting to add Renovate markers to see if Renovate can suggest upgrades.