### PR TITLE
chore: align Renovate marker with upsteam

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
     {
       "fileMatch": [".*"],
       "matchStrings": [
-        "renovate:\\s+datasource=(?<datasource>\\S+?) depName=(?<depName>\\S+?)( versioning=(?<versioning>\\S+?))?( registryUrl=(?<registryUrl>\\S+?))?\\s+(\\S+?_)?(VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*(?<currentValue>\\S+)",
+        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s",
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },


### PR DESCRIPTION
Aligning the syntax used with how the official regex matches are defined: https://docs.renovatebot.com/presets-regexManagers/

`\S` means everything non-space. `?:` means a non-capturing group.