### PR TITLE
ci(renovate): add 'packageName' support in marker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
     {
       "fileMatch": [".*"],
       "matchStrings": [
-        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s",
+        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: (packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s",
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
     {
       "fileMatch": [".*"],
       "matchStrings": [
-        "renovate:\\s+datasource=(?<datasource>\\S+?) depName=(?<depName>\\S+?)( versioning=(?<versioning>\\S+?))?( registryUrl=(?<registryUrl>\\S+?))?\\s+(\\S+?_)?(VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*(?<currentValue>\\S+)",
+        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s",
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

Adding support for `packageName=<packageName>` in Renovate marker.

See https://github.com/renovatebot/renovate/discussions/14885#discussioncomment-2482898 for more info on difference between `depName` and `packageName`.

This PR depends https://github.com/statnett/image-scanner-operator/pull/526.