### PR TITLE
ci: fix Go mod version to mend Dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/image-scanner-operator
 
-go 1.20
+go 1.21
 
 toolchain go1.21.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/statnett/image-scanner-operator
 
 go 1.20
 
+toolchain go1.21.0
+
 require (
 	github.com/distribution/distribution v2.8.2+incompatible
 	github.com/mitchellh/hashstructure/v2 v2.0.2


### PR DESCRIPTION
Dependabot is no longer suggesting Go updates:

![image](https://github.com/statnett/image-scanner-operator/assets/1142578/72ef1257-8fee-45e4-ba9f-df6d3c5d98e8)

Go a tip for a fix here: https://github.com/orgs/community/discussions/65431