### PR TITLE
test(e2e): remove obsolete Openshift daemonset node affinity

### DIFF
--- a/test/e2e/workload-scan/scan-daemon-set/00-create.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/00-create.yaml
@@ -23,19 +23,3 @@ spec:
             - name: app
               containerPort: 8080
               protocol: TCP
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  # Single node k3s cluster
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: In
-                    values:
-                      - "true"
-              - matchExpressions:
-                  # Openshift workers
-                  - key: node-role.kubernetes.io/worker
-                    operator: In
-                    values:
-                      - ''


### PR DESCRIPTION
Removing leftovers from when we ran e2e-tests on Openshift. Noted when causing trouble in https://github.com/statnett/image-scanner-operator/pull/549.