### PR TITLE
chore: add patch version to Golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.21@sha256:62e5883c278354041360e26dd3ba8c62c8621743a2b4fd7f0f0caf00af45d15c as builder
+FROM docker.io/library/golang:1.21.1@sha256:62e5883c278354041360e26dd3ba8c62c8621743a2b4fd7f0f0caf00af45d15c as builder
 ARG GOPROXY
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Which should make it a bit easier to understand the Renovate PRs.