### PR TITLE
ci: try GHCR cleanup with Statnett BOT token

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -14,6 +14,11 @@ jobs:
       packages: write # for snok/container-retention-policy to delete images
     runs-on: ubuntu-latest
     steps:
+      - id: token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
+          private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
       - name: Delete untagged container images older than a week
         uses: snok/container-retention-policy@04c70fd030033036d69c0057e0d125bf25820544 # v2.1.2
         with:
@@ -22,4 +27,4 @@ jobs:
           account-type: org
           org-name: statnett
           untagged-only: true
-          token: ${{ secrets.BOT_PAT }}
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
This is a test to see if we can use the new Statnett BOT for the clean GHCR workflow.