### PR TITLE
ci: reuse clean GHCR workflow

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -1,25 +1,16 @@
 ---
-name: Delete obsolete container images
+name: Delete Obsolete GHCR Images
 on:
   schedule:
     - cron: "0 1 * * *"  # every day at midnight
   workflow_dispatch:
-permissions:
-  contents: read
+
 jobs:
-  clean-ghcr:
-    name: Delete obsolete container images
-    if: ${{ github.repository == 'statnett/image-scanner-operator' }}
+  trigger:
+    uses: statnett/workflows/.github/workflows/clean-ghcr.yaml@main
+    with:
+      image-names: ${{ github.event.repository.name }}
+    secrets:
+      PAT: ${{ secrets.BOT_PAT }}
     permissions:
-      packages: write # for snok/container-retention-policy to delete images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete untagged container images older than a week
-        uses: snok/container-retention-policy@04c70fd030033036d69c0057e0d125bf25820544 # v2.1.2
-        with:
-          image-names: image-scanner-operator
-          cut-off: A week ago UTC
-          account-type: org
-          org-name: statnett
-          untagged-only: true
-          token: ${{ secrets.BOT_PAT }}
+      packages: write


### PR DESCRIPTION
Try using https://github.com/statnett/workflows/blob/main/.github/workflows/clean-ghcr.yaml - before rolling it out to more projects.