### PR TITLE
chore: use statnett renovate preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "github>statnett/renovate-presets",
     ":semanticCommitTypeAll(ci)",
-    "regexManagers:dockerfileVersions",
   ],
   "labels": ["dependencies"],
   "ignorePaths": [],
@@ -19,23 +18,6 @@
         "ghcr.io/aquasecurity/trivy",
       ],
       "semanticCommitType": "build",
-    },
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": [".*"],
-      "matchStrings": [
-        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: (packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s",
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-    },
-    {
-      "fileMatch": [".+\\.ya?ml$"],
-      "matchStrings": [
-        "# renovate-image:( versioning=(?<versioning>.*?))?\\n\\s*(.+?_IMAGE|image)[=:]\\s*(?<depName>.+?):(?<currentValue>.+?)(\\s|$)",
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
     },
   ],
 }


### PR DESCRIPTION
Use https://github.com/statnett/renovate-presets/ as Renovate preset. This is a preset that will be slim, only containing core config changes.

Our current regex dependencies should not changed by this PR.

<details><summary>Current regex dependencies</summary>

![image](https://github.com/statnett/image-scanner-operator/assets/104485047/53329674-2d87-449d-afd5-e8d3ae3d6606)

</details>