### PR TITLE
fix: golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           # renovate: datasource=go depName=github.com/golangci/golangci-lint
           version: v1.54.2
           args: --timeout 5m
-          only-new-issues: true
   yaml-lint:
     runs-on: ubuntu-latest
     steps:

--- a/api/stas/v1alpha1/containerimagescan_types.go
+++ b/api/stas/v1alpha1/containerimagescan_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/distribution/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/statnett/image-scanner-operator
 go 1.20
 
 require (
-	github.com/distribution/distribution v2.8.3+incompatible
+	github.com/distribution/reference v0.5.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.12.1
@@ -31,7 +31,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chigopher/pathlib v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/distribution/distribution v2.8.3+incompatible h1:RlpEXBLq/WPXYvBYMDAmBX/SnhD67qwtvW/DzKc8pAo=
-github.com/distribution/distribution v2.8.3+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/emicklei/go-restful/v3 v3.10.2 h1:hIovbnmBTLjHXkqEBUz3HGpXZdM7ZrE9fJIZIqlJLqE=

--- a/internal/controller/stas/types.go
+++ b/internal/controller/stas/types.go
@@ -1,7 +1,7 @@
 package stas
 
 import (
-	"github.com/distribution/distribution/reference"
+	"github.com/distribution/reference"
 	corev1 "k8s.io/api/core/v1"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"


### PR DESCRIPTION
There seems to have been an issue in our CI that allowed a PR with golangci-lint issues to be merged. Not sure why, but I am also disabling the `only-new-issues` option in this PR - as we should not have lint issues on the default branch.

Close https://github.com/statnett/image-scanner-operator/pull/615