### PR TITLE
chore: fix renovate config reference

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>statnett/renovate-presets",
+    "github>statnett/renovate-presets:default.json5",
     ":semanticCommitTypeAll(ci)",
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
It looks like we need to specify the filename when we are using JSON5, only `default.json` seems to be found automatically. Ref https://docs.renovatebot.com/config-presets/#github