### PR TITLE
chore(renovate): change org repo reference

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>statnett/renovate-presets",
+    "github>statnett/renovate-config",
     ":semanticCommitTypeAll(ci)",
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
To support [organization level sharing of presets](https://docs.renovatebot.com/config-presets/#organization-level-presets), the repo must be named "*renovate-config*".

Depends on: https://github.com/statnett/renovate-config/pull/6