### PR TITLE
ci: fix workflow import

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/lint-pr.yml@main
+    uses: statnett/github-workflows/.github/workflows/lint-pr.yaml@main
     permissions:
       pull-requests: write
       statuses: write


### PR DESCRIPTION
After renaming the repository *workflows*  to [github-workflows](https://github.com/statnett/github-workflows), we need to update our import. All file extensions was also [changed to `yaml`](https://github.com/statnett/github-workflows/commit/e5bb6c2ecceffd1d64b217682775a1e2f74ddb6b).