### PR TITLE
ci: add Renovate go mod tidy options

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,4 +12,9 @@
       "automerge": true,
     },
   ],
+  "postUpdateOptions": [
+    "gomodMassage",
+    "gomodTidy",
+    "gomodUpdateImportPaths",
+  ],
 }


### PR DESCRIPTION
This might fix the currently broken Renovate PR. Hopefully, we can promote this to the default config later on.