### PR TITLE
ci: cleanup obsolete Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,20 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>statnett/renovate-config",
-    ":semanticCommitTypeAll(ci)",
-  ],
-  "labels": ["dependencies"],
-  "ignorePaths": [],
+  "extends": ["github>statnett/renovate-config"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
     },
-  ],
-  "postUpdateOptions": [
-    "gomodMassage",
-    "gomodTidy",
-    "gomodUpdateImportPaths",
   ],
 }


### PR DESCRIPTION
After we switched to the default release-please configuration via reusable workflows, the Renovate config should be as default as possible. The Go mod settings are included in the default Renovate config now, so should not be required anymore, ref. https://github.com/statnett/renovate-config/pull/12.