### PR TITLE
fix: should set tag to latest if no tag on image

### DIFF
--- a/internal/controller/stas/types.go
+++ b/internal/controller/stas/types.go
@@ -61,7 +61,8 @@ func containerImages(pod *corev1.Pod) (map[string]*podContainerImage, error) {
 			continue
 		}
 
-		ref, err := reference.ParseAnyReference(container.Image)
+		// Using ParseDockerRef instead of ParseAnyReference to handle latest tag better
+		ref, err := reference.ParseDockerRef(container.Image)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/stas/types_test.go
+++ b/internal/controller/stas/types_test.go
@@ -149,6 +149,7 @@ var _ = Describe("ImageReference", func() {
 					Name:   "dummy.registry.mycorp.com/mysql",
 					Digest: "sha256:83469837189400492f32d23cadbfc97fae3dc019871337a841609f0b71a34907",
 				},
+				Tag: "latest",
 			}),
 	)
 })


### PR DESCRIPTION
We had an incident  with two replicasets owned by the same deployment and both replicaset pods were crash-looping. One replicaset explicitly used the latest tag, while the other implicitly used the latest tag (no tag). Since both pods use the same image digest, this created a situation where the two owner pods were fighting over the value of `spec.tag` on the shared ContainerImageScan resource.

This PR fixes this issue by making no tag default to the `latest` tag.