### PR TITLE
test: bump envTest to K8s 1.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= "registry.dummy-domain.com/image-scanner/controller:dev"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.0
+ENVTEST_K8S_VERSION = 1.28.0
 # Namespace to install operator into
 K8S_NAMESPACE ?= image-scanner
 

--- a/internal/controller/stas/containerimagescan_controller_test.go
+++ b/internal/controller/stas/containerimagescan_controller_test.go
@@ -120,8 +120,12 @@ var _ = Describe("ContainerImageScan controller", func() {
 		for k := range job.Spec.Template.Labels {
 			switch k {
 			case "controller-uid":
+				fallthrough
+			case "batch.kubernetes.io/controller-uid":
 				job.Spec.Template.Labels[k] = "<CONTROLLER-UID>"
 			case "job-name":
+				fallthrough
+			case "batch.kubernetes.io/job-name":
 				job.Spec.Template.Labels[k] = "<JOB-NAME>"
 			case stasv1alpha1.LabelStatnettControllerUID:
 				job.Spec.Template.Labels[k] = "<CIS-UID>"

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -2,8 +2,6 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    batch.kubernetes.io/job-tracking: ""
   generation: 1
   labels:
     app.kubernetes.io/managed-by: image-scanner
@@ -28,7 +26,9 @@ spec:
         app.kubernetes.io/managed-by: image-scanner
         app.kubernetes.io/name: trivy
         controller-uid: <CONTROLLER-UID>
+        batch.kubernetes.io/controller-uid: <CONTROLLER-UID>
         job-name: <JOB-NAME>
+        batch.kubernetes.io/job-name: <JOB-NAME>
         controller.statnett.no/namespace: replica-set
         controller.statnett.no/uid: <CIS-UID>
         workload.statnett.no/kind: Pod


### PR DESCRIPTION
It seems like we forgot to bump envTest K8s. I don't know if it's possible to get Renovate to care for this, as I have no idea where the releases are mastered. It's downloaded from https://storage.googleapis.com/kubebuilder-tools, but I have no idea where the releases come from.