### PR TITLE
build: replace goimports with gci

### DIFF
--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -30,7 +30,6 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
 	"github.com/statnett/image-scanner-operator/internal/pod"
-	//+kubebuilder:scaffold:imports
 )
 
 const scanJobNamespace = "image-scanner"


### PR DESCRIPTION
In order to avoid attempts to reformat generated files, ref. https://github.com/statnett/image-scanner-operator/pull/668, we should replace goimports with the more flexible alternative https://github.com/daixiang0/gci.