### PR TITLE
chore(ssa): rename binary to get less generic field owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot@sha256:91ca4720011393f4d4cab3a01fa5814ee2714b7d40e6c74f2505f74168398ca9
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/manager /image-scanner-operator
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/image-scanner-operator"]

--- a/config/manager/manager_patch.yaml
+++ b/config/manager/manager_patch.yaml
@@ -9,6 +9,8 @@ spec:
     spec:
       containers:
         - name: manager
+          command:
+            - /image-scanner-operator
           args:
             - --leader-elect
           envFrom:


### PR DESCRIPTION
Before we start our migration to SSA, we need to ensure that we can hand over field ownership correctly, ref. https://github.com/kubernetes/kubernetes/issues/99003. Since the K8s client defaults the field owner to the name of the binary, we should rename the binary to get a less generic `manager` value for resources `managedFields`. Currently it may look like this (example):

````yaml
  managedFields:
    - apiVersion: stas.statnett.no/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:labels':
            .: {}
            'f:control-plane': {}
            'f:pod-template-hash': {}
          'f:ownerReferences':
            .: {}
            'k:{"uid":"7f0ab8d9-5e1c-45b4-911e-ffe73166e33e"}': {}
        'f:spec':
          .: {}
          'f:digest': {}
          'f:ignoreUnfixed': {}
          'f:name': {}
          'f:tag': {}
          'f:workload':
            .: {}
            'f:containerName': {}
            'f:group': {}
            'f:kind': {}
            'f:name': {}
      manager: manager
      operation: Update
      time: '2023-10-05T20:06:16Z'
    - apiVersion: stas.statnett.no/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:lastScanJobUID': {}
          'f:lastScanTime': {}
          'f:lastSuccessfulScanTime': {}
          'f:observedGeneration': {}
          'f:vulnerabilitySummary':
            .: {}
            'f:fixedCount': {}
            'f:severityCount': {}
            'f:unfixedCount': {}
      manager: manager
      operation: Update
      subresource: status
      time: '2023-10-26T08:59:02Z'
````