### PR TITLE
fix(kustomize): migrate away from deprected patchesStrategicMerge

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,15 +5,15 @@ resources:
   - bases/stas.statnett.no_containerimagescans.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_stas_containerimagescans.yaml
+#  - path: patches/webhook_in_stas_containerimagescans.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_stas_containerimagescans.yaml
+#  - path: patches/cainjection_in_stas_containerimagescans.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - manager.yaml
-patchesStrategicMerge:
-  - manager_patch.yaml
+patches:
+  - path: manager_patch.yaml
 configMapGenerator:
   - literals:
       - CIS_METRICS_LABELS=app.kubernetes.io/name

--- a/config/operator/kustomization.yaml
+++ b/config/operator/kustomization.yaml
@@ -26,20 +26,20 @@ resources:
   # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
   - ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-#- manager_auth_proxy_patch.yaml
+#  - path: manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#  - path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#  - path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
Fix deprecation warning when running `kustomize build`
```
$ kustomize build
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```