### PR TITLE
chore(deps): upgrade tj-actions/verify-changed-files → 13.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           make generate-all
       - name: Verify changed files
-        uses: tj-actions/verify-changed-files@9ed3155b72ba709881c967f75611fc5852f773b9 # v13.1
+        uses: tj-actions/verify-changed-files@f557547e643700f439745119efed5aac390db75d # v13.2.0
         id: verify-changed-files
         with:
           files: |


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

Renovate does not seem to work with the 13.1 version syntax (only major.minor), I would like to try with full semver and see if Renovate will suggest updates to this dependency then.

Related to https://github.com/statnett/image-scanner-operator/pull/759