### PR TITLE
feat: add rootfs as an alternative to default filesystem Trivy scanning

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ func (c *TrivyCommand) UnmarshalText(text []byte) error {
 	if !c.unmarshalText(text) {
 		return fmt.Errorf("unrecognized trivy command: %q", text)
 	}
+
 	return nil
 }
 
@@ -50,5 +51,6 @@ func (c *TrivyCommand) unmarshalText(text []byte) bool {
 	default:
 		return false
 	}
+
 	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"time"
 )
@@ -15,5 +17,38 @@ type Config struct {
 	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
 	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
 	TrivyImage                 string         `mapstructure:"trivy-image"`
+	TrivyCommand               TrivyCommand   `mapstructure:"trivy-command"`
 	ActiveScanJobLimit         int            `mapstructure:"active-scan-job-limit"`
+}
+
+type TrivyCommand string
+
+const (
+	FilesystemTrivyCommand TrivyCommand = "filesystem"
+	RootfsTrivyCommand     TrivyCommand = "rootfs"
+)
+
+var errUnmarshalNilLevel = errors.New("can't unmarshal a nil *TrivyCommand")
+
+// UnmarshalText unmarshals text to a trivy command.
+func (c *TrivyCommand) UnmarshalText(text []byte) error {
+	if c == nil {
+		return errUnmarshalNilLevel
+	}
+	if !c.unmarshalText(text) {
+		return fmt.Errorf("unrecognized trivy command: %q", text)
+	}
+	return nil
+}
+
+func (c *TrivyCommand) unmarshalText(text []byte) bool {
+	switch string(text) {
+	case "filesystem":
+		*c = FilesystemTrivyCommand
+	case "rootfs":
+		*c = RootfsTrivyCommand
+	default:
+		return false
+	}
+	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ func (c *TrivyCommand) UnmarshalText(text []byte) error {
 	if c == nil {
 		return errUnmarshalNilLevel
 	}
+
 	if !c.unmarshalText(text) {
 		return fmt.Errorf("unrecognized trivy command: %q", text)
 	}

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func() {
 		ScanJobNamespace:      scanJobNamespace,
 		ScanJobServiceAccount: "image-scanner-job",
 		ScanInterval:          time.Hour,
+		TrivyCommand:          config.FilesystemTrivyCommand,
 		TrivyImage:            "aquasecurity/trivy",
 	}
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -63,6 +63,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("scan-workload-resources", "", "A comma-separated list of workload resources to scan. Format used for resource is \"resource.group\", i.e. \"deployments.apps\".")
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")
+	fs.String("trivy-command", string(config.FilesystemTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
 	fs.Bool("help", false, "print out usage and a summary of options")
@@ -90,6 +91,7 @@ func (o Operator) UnmarshalConfig(cfg *config.Config) error {
 	hook := mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
+		mapstructure.TextUnmarshallerHookFunc(),
 		stringToRegexpHookFunc(),
 	)
 	if err := viper.Unmarshal(cfg, viper.DecodeHook(hook)); err != nil {

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -191,7 +191,7 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	container.Image = canonical.String()
 	container.Command = []string{FsScanTrivyBinaryPath}
 	container.Args = []string{
-		"filesystem",
+		string(f.TrivyCommand),
 		"/",
 	}
 	container.Env = []corev1.EnvVar{


### PR DESCRIPTION
I have been investigating why language-specific vulnerabilities are not detected by the scanner, and I think it's because it currently doesn't work when using the `filesystem` Trivy command. I started looking in this direction after finding https://github.com/aquasecurity/trivy/issues/4133#issuecomment-1664325976, and I want to experiment with the alternative `rootfs` command.