### PR TITLE
feat!: switch to rootfs scanning as new default

### DIFF
--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -108,7 +108,7 @@ var _ = BeforeSuite(func() {
 		ScanJobNamespace:      scanJobNamespace,
 		ScanJobServiceAccount: "image-scanner-job",
 		ScanInterval:          time.Hour,
-		TrivyCommand:          config.FilesystemTrivyCommand,
+		TrivyCommand:          config.RootfsTrivyCommand,
 		TrivyImage:            "aquasecurity/trivy",
 	}
 

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -48,7 +48,9 @@ spec:
       automountServiceAccountToken: false
       containers:
         - args:
-            - filesystem
+            - rootfs
+            - --skip-files
+            - /var/run/image-scanner/trivy
             - /
           command:
             - /var/run/image-scanner/trivy

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -63,7 +63,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("scan-workload-resources", "", "A comma-separated list of workload resources to scan. Format used for resource is \"resource.group\", i.e. \"deployments.apps\".")
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")
-	fs.String("trivy-command", string(config.FilesystemTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
+	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
 	fs.Bool("help", false, "print out usage and a summary of options")

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -192,6 +192,8 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	container.Command = []string{FsScanTrivyBinaryPath}
 	container.Args = []string{
 		string(f.TrivyCommand),
+		"--skip-files",
+		FsScanTrivyBinaryPath,
 		"/",
 	}
 	container.Env = []corev1.EnvVar{


### PR DESCRIPTION
After trying our `rootfs` scanning in our clusters, it seems like this scanning is a much better default. As a future feature we should probably allow the scanning type to be overridden by workload.

Also adding skip scanning the trivy binary - which currently has at least one HIGH vulnerability. Doing this with a flag - to ensure it overrides any ENVs configuring the same. It just don't make sense to include vulns in the scanner that we "import" into the image.