### PR TITLE
fix: use additional skip-files arg in scan job understood by Trivy

### DIFF
--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -50,6 +50,8 @@ spec:
         - args:
             - rootfs
             - --skip-files
+            - /var/run/image-scanner/trivy
+            - --skip-files
             - run/image-scanner/trivy
             - /
           command:

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -50,7 +50,7 @@ spec:
         - args:
             - rootfs
             - --skip-files
-            - /var/run/image-scanner/trivy
+            - run/image-scanner/trivy
             - /
           command:
             - /var/run/image-scanner/trivy

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -193,7 +193,9 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	container.Args = []string{
 		string(f.TrivyCommand),
 		"--skip-files",
-		FsScanTrivyBinaryPath,
+		// FIXME: Somehow Trivy strips off the first part of the path
+		"run/image-scanner/trivy",
+		// FsScanTrivyBinaryPath,
 		"/",
 	}
 	container.Env = []corev1.EnvVar{

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -193,9 +193,10 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	container.Args = []string{
 		string(f.TrivyCommand),
 		"--skip-files",
+		FsScanTrivyBinaryPath,
 		// FIXME: Somehow Trivy strips off the first part of the path
+		"--skip-files",
 		"run/image-scanner/trivy",
-		// FsScanTrivyBinaryPath,
 		"/",
 	}
 	container.Env = []corev1.EnvVar{


### PR DESCRIPTION
It seems like Trivy somehow strips off the first part of the path when walking the filesystem, which makes the `skip-files` argument added in https://github.com/statnett/image-scanner-operator/pull/850 non-effective. This PR is a workaround that sets the argument to a value making it effective.

To debug this, I created a long-running workload configured as our scan jobs.Without this fix, the vulnerabilities present in the trivy binary is reported. Note the path presented in the report!

````
run/image-scanner/trivy (gobinary)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 1, CRITICAL: 0)

┌────────────────────────────┬────────────────┬──────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│          Library           │ Vulnerability  │ Severity │  Status  │ Installed Version │ Fixed Version │                            Title                             │
├────────────────────────────┼────────────────┼──────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/protobuf │ CVE-2024-24786 │ MEDIUM   │ fixed    │ v1.32.0           │ 1.33.0        │ golang-protobuf: encoding/protojson, internal/encoding/json: │
│                            │                │          │          │                   │               │ infinite loop in protojson.Unmarshal when unmarshaling       │
│                            │                │          │          │                   │               │ certain forms of...                                          │
│                            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-24786                   │
├────────────────────────────┼────────────────┼──────────┤          ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ helm.sh/helm/v3            │ CVE-2024-26147 │ HIGH     │          │ v3.14.0           │ 3.14.2        │ helm: Missing YAML Content Leads To Panic                    │
│                            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-26147                   │
│                            ├────────────────┼──────────┼──────────┤                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                            │ CVE-2019-25210 │ MEDIUM   │ affected │                   │               │ helm: shows secrets with --dry-run option in clear text      │
│                            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-25210                   │
│                            ├────────────────┤          ├──────────┤                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                            │ CVE-2024-25620 │          │ fixed    │                   │ 3.14.1        │ helm: Dependency management path traversal                   │
│                            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-25620                   │
└────────────────────────────┴────────────────┴──────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
````