### PR TITLE
fix: ensure valid scan job name

### DIFF
--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -107,8 +107,9 @@ func scanJobName(cis *stasv1alpha1.ContainerImageScan) (string, error) {
 
 	name := nameFn(cis.Name)
 	if len(name) > KubernetesJobNameMaxLength {
+		shortenCISName := cis.Name[:len(cis.Name)-(len(name)-KubernetesJobNameMaxLength)]
 		// Must ensure the shortened name does not end with a '.' - which makes the job name invalid
-		shortenCISName := strings.Trim(cis.Name[0:len(cis.Name)-(len(name)-KubernetesJobNameMaxLength)], ".")
+		shortenCISName = strings.Trim(shortenCISName, ".")
 		name = nameFn(shortenCISName)
 	}
 

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -107,7 +107,8 @@ func scanJobName(cis *stasv1alpha1.ContainerImageScan) (string, error) {
 
 	name := nameFn(cis.Name)
 	if len(name) > KubernetesJobNameMaxLength {
-		shortenCISName := cis.Name[0 : len(cis.Name)-(len(name)-KubernetesJobNameMaxLength)]
+		// Must ensure the shortened name does not end with a '.' - which makes the job name invalid
+		shortenCISName := strings.Trim(cis.Name[0:len(cis.Name)-(len(name)-KubernetesJobNameMaxLength)], ".")
 		name = nameFn(shortenCISName)
 	}
 

--- a/internal/trivy/scan_job_test.go
+++ b/internal/trivy/scan_job_test.go
@@ -1,6 +1,8 @@
 package trivy
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -9,44 +11,78 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-var _ = Describe("Creating scan Job container", func() {
-	var jobBuilder *filesystemScanJobBuilder
-	var cisSpec stasv1alpha1.ContainerImageScanSpec
+var _ = Describe("Scan Job", func() {
+	Context("Creating Job container", func() {
+		var jobBuilder *filesystemScanJobBuilder
+		var cisSpec stasv1alpha1.ContainerImageScanSpec
 
-	BeforeEach(func() {
-		jobBuilder = &filesystemScanJobBuilder{}
-		cisSpec = stasv1alpha1.ContainerImageScanSpec{}
-		cisSpec.Image.Name = "foo.registry/bar"
-		cisSpec.Image.Digest = "sha256:f1645ab5fbbbcf9e3484d1506dd65fc9fb26dd6817cb3a0a64249d8a8973e170"
+		BeforeEach(func() {
+			jobBuilder = &filesystemScanJobBuilder{}
+			cisSpec = stasv1alpha1.ContainerImageScanSpec{}
+			cisSpec.Image.Name = "foo.registry/bar"
+			cisSpec.Image.Digest = "sha256:f1645ab5fbbbcf9e3484d1506dd65fc9fb26dd6817cb3a0a64249d8a8973e170"
+		})
+
+		Context("minimum severity config", func() {
+			It("should not include severity when minSeverity omitted", func() {
+				container, err := jobBuilder.container(cisSpec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(container.Env).To(Not(ContainElement(HaveField("Name", Equal("TRIVY_SEVERITY")))))
+			})
+
+			It("should set severity when minSeverity set", func() {
+				cisSpec.ScanConfig.MinSeverity = ptr.To("MEDIUM")
+				container, err := jobBuilder.container(cisSpec)
+				Expect(err).ToNot(HaveOccurred())
+				expectedSeverityEnv := corev1.EnvVar{
+					Name:  "TRIVY_SEVERITY",
+					Value: "MEDIUM,HIGH,CRITICAL",
+				}
+				Expect(container.Env).To(ContainElement(expectedSeverityEnv))
+			})
+
+			It("should set ignore-unfixed when ignoreUnfixed set", func() {
+				cisSpec.ScanConfig.IgnoreUnfixed = ptr.To(true)
+				container, err := jobBuilder.container(cisSpec)
+				Expect(err).ToNot(HaveOccurred())
+				expectedSeverityEnv := corev1.EnvVar{
+					Name:  "TRIVY_IGNORE_UNFIXED",
+					Value: "true",
+				}
+				Expect(container.Env).To(ContainElement(expectedSeverityEnv))
+			})
+		})
 	})
 
-	Context("minimum severity config", func() {
-		It("should not include severity when minSeverity omitted", func() {
-			container, err := jobBuilder.container(cisSpec)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(container.Env).To(Not(ContainElement(HaveField("Name", Equal("TRIVY_SEVERITY")))))
+	Context("Naming Job", func() {
+		var cis *stasv1alpha1.ContainerImageScan
+
+		BeforeEach(func() {
+			cis = &stasv1alpha1.ContainerImageScan{}
+			cis.Namespace = "foo"
+			cis.Name = "bar"
 		})
 
-		It("should set severity when minSeverity set", func() {
-			cisSpec.ScanConfig.MinSeverity = ptr.To("MEDIUM")
-			container, err := jobBuilder.container(cisSpec)
-			Expect(err).ToNot(HaveOccurred())
-			expectedSeverityEnv := corev1.EnvVar{
-				Name:  "TRIVY_SEVERITY",
-				Value: "MEDIUM,HIGH,CRITICAL",
-			}
-			Expect(container.Env).To(ContainElement(expectedSeverityEnv))
+		It("should use CIS name", func() {
+			Expect(scanJobName(cis)).To(Equal("bar-e4512"))
 		})
 
-		It("should set ignore-unfixed when ignoreUnfixed set", func() {
-			cisSpec.ScanConfig.IgnoreUnfixed = ptr.To(true)
-			container, err := jobBuilder.container(cisSpec)
-			Expect(err).ToNot(HaveOccurred())
-			expectedSeverityEnv := corev1.EnvVar{
-				Name:  "TRIVY_IGNORE_UNFIXED",
-				Value: "true",
-			}
-			Expect(container.Env).To(ContainElement(expectedSeverityEnv))
+		It("should truncate name if CIS name too long", func() {
+			cis.Name = strings.Repeat("a", 128)
+			Expect(scanJobName(cis)).To(
+				And(
+					Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-e4512"),
+					HaveLen(KubernetesJobNameMaxLength),
+				))
+		})
+
+		It("should truncate CIS name correctly if ends with `.`", func() {
+			cis.Name = "bar" + strings.Repeat("a.", 64)
+			Expect(scanJobName(cis)).To(
+				And(
+					Equal("bara.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a-e4512"),
+					HaveLen(KubernetesJobNameMaxLength-1),
+				))
 		})
 	})
 })


### PR DESCRIPTION
We observed this error message in one of our clusters today:

````
Job.batch "job-reserved-cross-zonal-capacity-backend-migrations-0.0.-976fb" is invalid: metadata.name: Invalid value: "job-reserved-cross-zonal-capacity-backend-migrations-0.0.-976fb": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
````

I've been looking into this issue: The CIS name is shortened when naming the scan job - to fit into a valid job name. When appending our hash to the CIS name (possibly shortened), we prefix the hash with `-`, and a `-` after a `.` is disallowed by the regex. This PR ensures that the shortened CIS name never ends with a `.`.