### PR TITLE
chore: reset CIS minSeverity in workload controller

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -149,6 +149,8 @@ func (r *PodReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
 			cis.Spec.Image = image.Image
 			cis.Spec.Tag = image.Tag
 
+			// Ensure MinSeverity unset until we eventually make use of it
+			cis.Spec.MinSeverity = nil
 			if v := podController.GetAnnotations()[stasv1alpha1.WorkloadAnnotationKeyIgnoreUnfixed]; v == "true" {
 				cis.Spec.IgnoreUnfixed = ptr.To(true)
 			} else {

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -148,9 +148,9 @@ func (r *PodReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
 			cis.Spec.Workload.ContainerName = containerName
 			cis.Spec.Image = image.Image
 			cis.Spec.Tag = image.Tag
-
 			// Ensure MinSeverity unset until we eventually make use of it
 			cis.Spec.MinSeverity = nil
+
 			if v := podController.GetAnnotations()[stasv1alpha1.WorkloadAnnotationKeyIgnoreUnfixed]; v == "true" {
 				cis.Spec.IgnoreUnfixed = ptr.To(true)
 			} else {


### PR DESCRIPTION
This is a leftover from https://github.com/statnett/image-scanner-operator/pull/861. Since we currently don't have a mechanism that allows users to set `minSeverity`, we should ensure it's unset on all CIS resources.