### PR TITLE
fix: move Trivy skip-files to job configmap

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,6 +11,8 @@ configMapGenerator:
     namespace: image-scanner
     literals:
       - SERVER=http://trivy.image-scanner.svc.cluster.local
+      # FIXME: The second skip path is needed since Trivy somehow removes leading parts from the actual path
+      - SKIP_FILES=/var/run/image-scanner/trivy,run/image-scanner/trivy
       - TIMEOUT=30m
 generatorOptions:
   disableNameSuffixHash: true

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -49,10 +49,6 @@ spec:
       containers:
         - args:
             - rootfs
-            - --skip-files
-            - /var/run/image-scanner/trivy
-            - --skip-files
-            - run/image-scanner/trivy
             - /
           command:
             - /var/run/image-scanner/trivy

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -194,11 +194,6 @@ func (f *filesystemScanJobBuilder) container(spec stasv1alpha1.ContainerImageSca
 	container.Command = []string{FsScanTrivyBinaryPath}
 	container.Args = []string{
 		string(f.TrivyCommand),
-		"--skip-files",
-		FsScanTrivyBinaryPath,
-		// FIXME: Somehow Trivy strips off the first part of the path
-		"--skip-files",
-		"run/image-scanner/trivy",
 		"/",
 	}
 	container.Env = []corev1.EnvVar{


### PR DESCRIPTION
This is another attempt to make the Trivy skip-files configuration work; moving the skip-files config from args to the default job configmap. Also allows the user to eventually override the setting, which could be considered a feature. 