### PR TITLE
chore: upgrade Go mod requirements to Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       K3D_VERSION: v5.6.3
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: go.mod
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/image-scanner-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/distribution/reference v0.6.0


### PR DESCRIPTION
Required to upgrade K8s dependencies. It would be nice if Renovate could suggest PRs like this, but it seems like it insists on a full Go version requirement - which is very uncommon and something I would like to avoid.

Also fixing a missing requirement on Go in the e2e-tests job detected when attempting to perform a simple upgrade.