### PR TITLE
chore(deps): update module sigs.k8s.io/controller-tools to v0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ KUSTOMIZE_VERSION ?= v5.4.1
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
 CODE_GENERATOR_VERSION ?= v0.29.3
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: applyconfiguration-gen
 applyconfiguration-gen: $(APPLYCONFIGURATION_GEN) ## Download applyconfiguration-gen locally if necessary.

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: containerimagescans.stas.statnett.no
 spec:
   group: stas.statnett.no


### PR DESCRIPTION
Replacement for https://github.com/statnett/image-scanner-operator/pull/902, as a regen is required.

Close https://github.com/statnett/image-scanner-operator/pull/902