### PR TITLE
chore(deps): update module github.com/kubernetes/code-generator to v0.30.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ k8s-client-gen: applyconfiguration-gen
 # For now I (erikgb) updated the command, but kept the files generated with v0.29.3
 .PHONY: wg-policy-client-gen
 wg-policy-client-gen: applyconfiguration-gen
-	rm -rf internal/wg-policy/applyconfiguration
 	@echo ">> generating internal/wg-policy/applyconfiguration..."
 	$(APPLYCONFIGURATION_GEN) \
 		--output-dir "internal/wg-policy/applyconfiguration" \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ generate: controller-gen k8s-client-gen ## Generate code required for K8s API an
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 GO_MODULE = $(shell go list -m)
-API_DIRS = $(shell find api -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd ",")
+API_DIRS = $(shell find api -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd " ")
 .PHONY: k8s-client-gen
 k8s-client-gen: applyconfiguration-gen
 	@echo ">> generating internal/client/applyconfiguration..."

--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,8 @@ GCI_VERSION ?= v0.13.4
 ## Tool Versions
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.1
-# TODO: Waiting for v0.30.1
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
-CODE_GENERATOR_VERSION ?= master
+CODE_GENERATOR_VERSION ?= v0.30.1
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,6 @@ k8s-client-gen: applyconfiguration-gen
 		--output-pkg "$(GO_MODULE)/internal/client/applyconfiguration" \
 		$(API_DIRS)
 
-# FIXME: This target does not generate something that compiles after upgrade to v0.30.0
-# The following issue might be relevant: https://github.com/kubernetes/code-generator/issues/168
-# For now I (erikgb) updated the command, but kept the files generated with v0.29.3
 .PHONY: wg-policy-client-gen
 wg-policy-client-gen: applyconfiguration-gen
 	@echo ">> generating internal/wg-policy/applyconfiguration..."
@@ -195,6 +192,7 @@ GCI_VERSION ?= v0.13.4
 ## Tool Versions
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.1
+# TODO: Waiting for v0.30.1
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
 CODE_GENERATOR_VERSION ?= master
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ GCI_VERSION ?= v0.13.4
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.1
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
-CODE_GENERATOR_VERSION ?= v0.30.0
+CODE_GENERATOR_VERSION ?= master
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 

--- a/Makefile
+++ b/Makefile
@@ -52,25 +52,23 @@ GO_MODULE = $(shell go list -m)
 API_DIRS = $(shell find api -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd ",")
 .PHONY: k8s-client-gen
 k8s-client-gen: applyconfiguration-gen
-	rm -rf internal/client/applyconfiguration
 	@echo ">> generating internal/client/applyconfiguration..."
 	$(APPLYCONFIGURATION_GEN) \
-		--go-header-file 	hack/boilerplate.go.txt \
-		--input-dirs		"$(API_DIRS)" \
-		--output-package  	"$(GO_MODULE)/internal/client/applyconfiguration" \
-		--trim-path-prefix 	"$(GO_MODULE)" \
-		--output-base    	"."
+		--output-dir "internal/client/applyconfiguration" \
+		--output-pkg "$(GO_MODULE)/internal/client/applyconfiguration" \
+		$(API_DIRS)
 
+# FIXME: This target does not generate something that compiles after upgrade to v0.30.0
+# The following issue might be relevant: https://github.com/kubernetes/code-generator/issues/168
+# For now I (erikgb) updated the command, but kept the files generated with v0.29.3
 .PHONY: wg-policy-client-gen
 wg-policy-client-gen: applyconfiguration-gen
 	rm -rf internal/wg-policy/applyconfiguration
 	@echo ">> generating internal/wg-policy/applyconfiguration..."
 	$(APPLYCONFIGURATION_GEN) \
-		--go-header-file 	hack/boilerplate.go.txt \
-		--input-dirs		"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2" \
-		--output-package  	"$(GO_MODULE)/internal/wg-policy/applyconfiguration" \
-		--trim-path-prefix 	"$(GO_MODULE)" \
-		--output-base    	"."
+		--output-dir "internal/wg-policy/applyconfiguration" \
+		--output-pkg "$(GO_MODULE)/internal/wg-policy/applyconfiguration" \
+		"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2"
 
 .PHONY: wg-policy-crd-update
 wg-policy-crd-update:
@@ -199,7 +197,7 @@ GCI_VERSION ?= v0.13.4
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.1
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
-CODE_GENERATOR_VERSION ?= v0.29.3
+CODE_GENERATOR_VERSION ?= v0.30.0
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 

--- a/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanstatus.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanstatus.go
@@ -5,6 +5,7 @@ package v1alpha1
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // ContainerImageScanStatusApplyConfiguration represents an declarative configuration of the ContainerImageScanStatus type for use
@@ -14,7 +15,7 @@ type ContainerImageScanStatusApplyConfiguration struct {
 	LastScanJobUID         *types.UID                              `json:"lastScanJobUID,omitempty"`
 	LastScanTime           *v1.Time                                `json:"lastScanTime,omitempty"`
 	LastSuccessfulScanTime *v1.Time                                `json:"lastSuccessfulScanTime,omitempty"`
-	Conditions             []v1.Condition                          `json:"conditions,omitempty"`
+	Conditions             []metav1.ConditionApplyConfiguration    `json:"conditions,omitempty"`
 	Vulnerabilities        []VulnerabilityApplyConfiguration       `json:"vulnerabilities,omitempty"`
 	VulnerabilitySummary   *VulnerabilitySummaryApplyConfiguration `json:"vulnerabilitySummary,omitempty"`
 }
@@ -60,9 +61,12 @@ func (b *ContainerImageScanStatusApplyConfiguration) WithLastSuccessfulScanTime(
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
-func (b *ContainerImageScanStatusApplyConfiguration) WithConditions(values ...v1.Condition) *ContainerImageScanStatusApplyConfiguration {
+func (b *ContainerImageScanStatusApplyConfiguration) WithConditions(values ...*metav1.ConditionApplyConfiguration) *ContainerImageScanStatusApplyConfiguration {
 	for i := range values {
-		b.Conditions = append(b.Conditions, values[i])
+		if values[i] == nil {
+			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
 	}
 	return b
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
@@ -3,6 +3,7 @@
 package v1beta2
 
 import (
+	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -14,12 +15,12 @@ import (
 type ClusterPolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Source                           *string                                      `json:"source,omitempty"`
-	Scope                            *corev1.ObjectReference                      `json:"scope,omitempty"`
-	ScopeSelector                    *metav1.LabelSelector                        `json:"scopeSelector,omitempty"`
-	Configuration                    *PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
-	Summary                          *PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
-	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
+	Source                           *string                                              `json:"source,omitempty"`
+	Scope                            *corev1.ObjectReference                              `json:"scope,omitempty"`
+	ScopeSelector                    *v1.LabelSelectorApplyConfiguration                  `json:"scopeSelector,omitempty"`
+	Configuration                    *v1beta2.PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
+	Summary                          *v1beta2.PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
+	Results                          []v1beta2.PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
 // ClusterPolicyReport constructs an declarative configuration of the ClusterPolicyReport type for use with
@@ -209,15 +210,15 @@ func (b *ClusterPolicyReportApplyConfiguration) WithScope(value corev1.ObjectRef
 // WithScopeSelector sets the ScopeSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ScopeSelector field is set to the value of the last call.
-func (b *ClusterPolicyReportApplyConfiguration) WithScopeSelector(value metav1.LabelSelector) *ClusterPolicyReportApplyConfiguration {
-	b.ScopeSelector = &value
+func (b *ClusterPolicyReportApplyConfiguration) WithScopeSelector(value *v1.LabelSelectorApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+	b.ScopeSelector = value
 	return b
 }
 
 // WithConfiguration sets the Configuration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Configuration field is set to the value of the last call.
-func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *PolicyReportConfigurationApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *v1beta2.PolicyReportConfigurationApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	b.Configuration = value
 	return b
 }
@@ -225,7 +226,7 @@ func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *PolicyR
 // WithSummary sets the Summary field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Summary field is set to the value of the last call.
-func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *PolicyReportSummaryApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *v1beta2.PolicyReportSummaryApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	b.Summary = value
 	return b
 }
@@ -233,7 +234,7 @@ func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *PolicyReportS
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Results field.
-func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResultApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*v1beta2.PolicyReportResultApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResults")

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
@@ -3,7 +3,6 @@
 package v1beta2
 
 import (
-	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -15,12 +14,12 @@ import (
 type ClusterPolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Source                           *string                                              `json:"source,omitempty"`
-	Scope                            *corev1.ObjectReference                              `json:"scope,omitempty"`
-	ScopeSelector                    *v1.LabelSelectorApplyConfiguration                  `json:"scopeSelector,omitempty"`
-	Configuration                    *v1beta2.PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
-	Summary                          *v1beta2.PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
-	Results                          []v1beta2.PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
+	Source                           *string                                      `json:"source,omitempty"`
+	Scope                            *corev1.ObjectReference                      `json:"scope,omitempty"`
+	ScopeSelector                    *v1.LabelSelectorApplyConfiguration          `json:"scopeSelector,omitempty"`
+	Configuration                    *PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
+	Summary                          *PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
+	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
 // ClusterPolicyReport constructs an declarative configuration of the ClusterPolicyReport type for use with
@@ -218,7 +217,7 @@ func (b *ClusterPolicyReportApplyConfiguration) WithScopeSelector(value *v1.Labe
 // WithConfiguration sets the Configuration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Configuration field is set to the value of the last call.
-func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *v1beta2.PolicyReportConfigurationApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *PolicyReportConfigurationApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	b.Configuration = value
 	return b
 }
@@ -226,7 +225,7 @@ func (b *ClusterPolicyReportApplyConfiguration) WithConfiguration(value *v1beta2
 // WithSummary sets the Summary field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Summary field is set to the value of the last call.
-func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *v1beta2.PolicyReportSummaryApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *PolicyReportSummaryApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	b.Summary = value
 	return b
 }
@@ -234,7 +233,7 @@ func (b *ClusterPolicyReportApplyConfiguration) WithSummary(value *v1beta2.Polic
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Results field.
-func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*v1beta2.PolicyReportResultApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
+func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResultApplyConfiguration) *ClusterPolicyReportApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResults")

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
@@ -3,7 +3,6 @@
 package v1beta2
 
 import (
-	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -15,12 +14,12 @@ import (
 type PolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Source                           *string                                              `json:"source,omitempty"`
-	Scope                            *corev1.ObjectReference                              `json:"scope,omitempty"`
-	ScopeSelector                    *v1.LabelSelectorApplyConfiguration                  `json:"scopeSelector,omitempty"`
-	Configuration                    *v1beta2.PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
-	Summary                          *v1beta2.PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
-	Results                          []v1beta2.PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
+	Source                           *string                                      `json:"source,omitempty"`
+	Scope                            *corev1.ObjectReference                      `json:"scope,omitempty"`
+	ScopeSelector                    *v1.LabelSelectorApplyConfiguration          `json:"scopeSelector,omitempty"`
+	Configuration                    *PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
+	Summary                          *PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
+	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
 // PolicyReport constructs an declarative configuration of the PolicyReport type for use with
@@ -219,7 +218,7 @@ func (b *PolicyReportApplyConfiguration) WithScopeSelector(value *v1.LabelSelect
 // WithConfiguration sets the Configuration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Configuration field is set to the value of the last call.
-func (b *PolicyReportApplyConfiguration) WithConfiguration(value *v1beta2.PolicyReportConfigurationApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithConfiguration(value *PolicyReportConfigurationApplyConfiguration) *PolicyReportApplyConfiguration {
 	b.Configuration = value
 	return b
 }
@@ -227,7 +226,7 @@ func (b *PolicyReportApplyConfiguration) WithConfiguration(value *v1beta2.Policy
 // WithSummary sets the Summary field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Summary field is set to the value of the last call.
-func (b *PolicyReportApplyConfiguration) WithSummary(value *v1beta2.PolicyReportSummaryApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithSummary(value *PolicyReportSummaryApplyConfiguration) *PolicyReportApplyConfiguration {
 	b.Summary = value
 	return b
 }
@@ -235,7 +234,7 @@ func (b *PolicyReportApplyConfiguration) WithSummary(value *v1beta2.PolicyReport
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Results field.
-func (b *PolicyReportApplyConfiguration) WithResults(values ...*v1beta2.PolicyReportResultApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResultApplyConfiguration) *PolicyReportApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResults")

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
@@ -3,6 +3,7 @@
 package v1beta2
 
 import (
+	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -14,12 +15,12 @@ import (
 type PolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Source                           *string                                      `json:"source,omitempty"`
-	Scope                            *corev1.ObjectReference                      `json:"scope,omitempty"`
-	ScopeSelector                    *metav1.LabelSelector                        `json:"scopeSelector,omitempty"`
-	Configuration                    *PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
-	Summary                          *PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
-	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
+	Source                           *string                                              `json:"source,omitempty"`
+	Scope                            *corev1.ObjectReference                              `json:"scope,omitempty"`
+	ScopeSelector                    *v1.LabelSelectorApplyConfiguration                  `json:"scopeSelector,omitempty"`
+	Configuration                    *v1beta2.PolicyReportConfigurationApplyConfiguration `json:"configuration,omitempty"`
+	Summary                          *v1beta2.PolicyReportSummaryApplyConfiguration       `json:"summary,omitempty"`
+	Results                          []v1beta2.PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
 // PolicyReport constructs an declarative configuration of the PolicyReport type for use with
@@ -210,15 +211,15 @@ func (b *PolicyReportApplyConfiguration) WithScope(value corev1.ObjectReference)
 // WithScopeSelector sets the ScopeSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ScopeSelector field is set to the value of the last call.
-func (b *PolicyReportApplyConfiguration) WithScopeSelector(value metav1.LabelSelector) *PolicyReportApplyConfiguration {
-	b.ScopeSelector = &value
+func (b *PolicyReportApplyConfiguration) WithScopeSelector(value *v1.LabelSelectorApplyConfiguration) *PolicyReportApplyConfiguration {
+	b.ScopeSelector = value
 	return b
 }
 
 // WithConfiguration sets the Configuration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Configuration field is set to the value of the last call.
-func (b *PolicyReportApplyConfiguration) WithConfiguration(value *PolicyReportConfigurationApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithConfiguration(value *v1beta2.PolicyReportConfigurationApplyConfiguration) *PolicyReportApplyConfiguration {
 	b.Configuration = value
 	return b
 }
@@ -226,7 +227,7 @@ func (b *PolicyReportApplyConfiguration) WithConfiguration(value *PolicyReportCo
 // WithSummary sets the Summary field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Summary field is set to the value of the last call.
-func (b *PolicyReportApplyConfiguration) WithSummary(value *PolicyReportSummaryApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithSummary(value *v1beta2.PolicyReportSummaryApplyConfiguration) *PolicyReportApplyConfiguration {
 	b.Summary = value
 	return b
 }
@@ -234,7 +235,7 @@ func (b *PolicyReportApplyConfiguration) WithSummary(value *PolicyReportSummaryA
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Results field.
-func (b *PolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResultApplyConfiguration) *PolicyReportApplyConfiguration {
+func (b *PolicyReportApplyConfiguration) WithResults(values ...*v1beta2.PolicyReportResultApplyConfiguration) *PolicyReportApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResults")

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
@@ -2,14 +2,10 @@
 
 package v1beta2
 
-import (
-	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
-)
-
 // PolicyReportConfigurationApplyConfiguration represents an declarative configuration of the PolicyReportConfiguration type for use
 // with apply.
 type PolicyReportConfigurationApplyConfiguration struct {
-	Limits *v1beta2.LimitsApplyConfiguration `json:"limits,omitempty"`
+	Limits *LimitsApplyConfiguration `json:"limits,omitempty"`
 }
 
 // PolicyReportConfigurationApplyConfiguration constructs an declarative configuration of the PolicyReportConfiguration type for use with
@@ -21,7 +17,7 @@ func PolicyReportConfiguration() *PolicyReportConfigurationApplyConfiguration {
 // WithLimits sets the Limits field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Limits field is set to the value of the last call.
-func (b *PolicyReportConfigurationApplyConfiguration) WithLimits(value *v1beta2.LimitsApplyConfiguration) *PolicyReportConfigurationApplyConfiguration {
+func (b *PolicyReportConfigurationApplyConfiguration) WithLimits(value *LimitsApplyConfiguration) *PolicyReportConfigurationApplyConfiguration {
 	b.Limits = value
 	return b
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
@@ -2,10 +2,14 @@
 
 package v1beta2
 
+import (
+	v1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
+)
+
 // PolicyReportConfigurationApplyConfiguration represents an declarative configuration of the PolicyReportConfiguration type for use
 // with apply.
 type PolicyReportConfigurationApplyConfiguration struct {
-	Limits *LimitsApplyConfiguration `json:"limits,omitempty"`
+	Limits *v1beta2.LimitsApplyConfiguration `json:"limits,omitempty"`
 }
 
 // PolicyReportConfigurationApplyConfiguration constructs an declarative configuration of the PolicyReportConfiguration type for use with
@@ -17,7 +21,7 @@ func PolicyReportConfiguration() *PolicyReportConfigurationApplyConfiguration {
 // WithLimits sets the Limits field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Limits field is set to the value of the last call.
-func (b *PolicyReportConfigurationApplyConfiguration) WithLimits(value *LimitsApplyConfiguration) *PolicyReportConfigurationApplyConfiguration {
+func (b *PolicyReportConfigurationApplyConfiguration) WithLimits(value *v1beta2.LimitsApplyConfiguration) *PolicyReportConfigurationApplyConfiguration {
 	b.Limits = value
 	return b
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportresult.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportresult.go
@@ -5,24 +5,25 @@ package v1beta2
 import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	v1beta2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2"
 )
 
 // PolicyReportResultApplyConfiguration represents an declarative configuration of the PolicyReportResult type for use
 // with apply.
 type PolicyReportResultApplyConfiguration struct {
-	Source           *string                       `json:"source,omitempty"`
-	Policy           *string                       `json:"policy,omitempty"`
-	Rule             *string                       `json:"rule,omitempty"`
-	Category         *string                       `json:"category,omitempty"`
-	Severity         *v1beta2.PolicyResultSeverity `json:"severity,omitempty"`
-	Timestamp        *v1.Timestamp                 `json:"timestamp,omitempty"`
-	Result           *v1beta2.PolicyResult         `json:"result,omitempty"`
-	Scored           *bool                         `json:"scored,omitempty"`
-	Subjects         []corev1.ObjectReference      `json:"resources,omitempty"`
-	ResourceSelector *v1.LabelSelector             `json:"resourceSelector,omitempty"`
-	Description      *string                       `json:"message,omitempty"`
-	Properties       map[string]string             `json:"properties,omitempty"`
+	Source           *string                                 `json:"source,omitempty"`
+	Policy           *string                                 `json:"policy,omitempty"`
+	Rule             *string                                 `json:"rule,omitempty"`
+	Category         *string                                 `json:"category,omitempty"`
+	Severity         *v1beta2.PolicyResultSeverity           `json:"severity,omitempty"`
+	Timestamp        *v1.Timestamp                           `json:"timestamp,omitempty"`
+	Result           *v1beta2.PolicyResult                   `json:"result,omitempty"`
+	Scored           *bool                                   `json:"scored,omitempty"`
+	Subjects         []corev1.ObjectReference                `json:"resources,omitempty"`
+	ResourceSelector *metav1.LabelSelectorApplyConfiguration `json:"resourceSelector,omitempty"`
+	Description      *string                                 `json:"message,omitempty"`
+	Properties       map[string]string                       `json:"properties,omitempty"`
 }
 
 // PolicyReportResultApplyConfiguration constructs an declarative configuration of the PolicyReportResult type for use with
@@ -108,8 +109,8 @@ func (b *PolicyReportResultApplyConfiguration) WithSubjects(values ...corev1.Obj
 // WithResourceSelector sets the ResourceSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ResourceSelector field is set to the value of the last call.
-func (b *PolicyReportResultApplyConfiguration) WithResourceSelector(value v1.LabelSelector) *PolicyReportResultApplyConfiguration {
-	b.ResourceSelector = &value
+func (b *PolicyReportResultApplyConfiguration) WithResourceSelector(value *metav1.LabelSelectorApplyConfiguration) *PolicyReportResultApplyConfiguration {
+	b.ResourceSelector = value
 	return b
 }
 


### PR DESCRIPTION
Alternative to https://github.com/statnett/image-scanner-operator/pull/897 - fixing the breaking changes.

~~I wasn't able to generate applyconfigurations for https://github.com/kubernetes-sigs/wg-policy-prototypes resources with the newer version, but I suggest we leave it for now - as we haven't started using them.~~ UPDATE: This issue seems to be caused by a regression in v0.30.0 - this a fix that will be released with v0.30.1. And now released.