### PR TITLE
ci: fix broken link to reusable workflow

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -9,6 +9,6 @@ permissions:
   contents: read
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/clean-ghcr.yaml@main
+    uses: statnett/github-workflows/.github/workflows/clean-ghcr.yaml@main
     permissions:
       packages: write


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

It seems like we forgot to update the link when the workflows project was renamed.