### PR TITLE
chore: remove toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/statnett/image-scanner-operator
 
 go 1.22.0
 
-toolchain go1.22.2
-
 require (
 	github.com/distribution/reference v0.6.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2


### PR DESCRIPTION
It seems like Renovate adds it, and I would prefer to avoid getting PRs for bumping the toolchain.