### PR TITLE
ci: fix verify-changed-files GH security advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
             **/*
       - name: Fail job is any changed files
         if: steps.verify-changed-files.outputs.files_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
         run: |
           errorMsg="::error::\
-            Changed files: ${{ steps.verify-changed-files.outputs.changed_files }}\
+            Changed files: $CHANGED_FILES\
             \nPlease run 'make generate-all' locally and commit the changes"
           echo -e "$errorMsg" && exit 1
   test:


### PR DESCRIPTION
Ref. https://github.com/advisories/GHSA-ghm2-rq8q-wrhc

https://github.com/statnett/image-scanner-operator/pull/947 has broken CI.

