### PR TITLE
build: add type constraint to avoid warning in IDEA

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -62,7 +62,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	predicates := []predicate.Predicate{
-		predicate.Not(managedByImageScanner),
+		predicate.Not[client.Object](managedByImageScanner),
 	}
 	if r.ScanNamespaceExcludeRegexp != nil {
 		predicates = append(predicates, predicate.Not(namespaceMatchRegexp(r.ScanNamespaceExcludeRegexp)))


### PR DESCRIPTION
Somehow this change is required to make IDEA happy. No idea why,