### PR TITLE
feat: reconcile cis with all owning pods

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -135,7 +135,10 @@ func (r *PodReconciler) cisOwnerLookup(ctx context.Context, pod *corev1.Pod) (fu
 	index := map[string][]corev1.Pod{}
 
 	for _, sibling := range siblings.Items {
-		// Ignore errors to not fail when parsing images of sibling Pod fails
+		// For the Pod being reconciled, `containerImages` errors are caught in
+		// `reconcile` (assuming the Pod is fetched identically by Get and
+		// List). Ignoring errors here to simply skip all sibling who's image
+		// cannot be parsed, as those Pods will fail in their own `reconcile`.
 		images, _ := containerImages(&sibling)
 		for containerName, image := range images {
 			k := key(containerName, image)

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -138,6 +138,7 @@ func (r *PodReconciler) imagePodIndex(ctx context.Context, pod *corev1.Pod) (map
 			if err != nil {
 				return nil, err
 			}
+			
 			index[id] = append(index[id], sibling)
 		}
 	}

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -195,7 +195,12 @@ func (r *PodReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
 				cis.Spec.IgnoreUnfixed = ptr.To(false)
 			}
 
-			for _, owner := range getCISOwners(containerName, image) {
+			owners := getCISOwners(containerName, image)
+			if len(owners) == 0 {
+				// Safeguard to validate assumption in `cisOwnerLookup`.
+				return fmt.Errorf("Found no owners for CIS", pod.Name)
+			}
+			for _, owner := range owners {
 				if err := controllerutil.SetOwnerReference(&owner, cis, r.Scheme); err != nil {
 					return err
 				}

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -2,6 +2,7 @@ package stas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -198,8 +199,9 @@ func (r *PodReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
 			owners := getCISOwners(containerName, image)
 			if len(owners) == 0 {
 				// Safeguard to validate assumption in `cisOwnerLookup`.
-				return fmt.Errorf("Found no owners for CIS", pod.Name)
+				return errors.New("Found no owners for CIS")
 			}
+
 			for _, owner := range owners {
 				if err := controllerutil.SetOwnerReference(&owner, cis, r.Scheme); err != nil {
 					return err

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -138,7 +138,7 @@ func (r *PodReconciler) imagePodIndex(ctx context.Context, pod *corev1.Pod) (map
 			if err != nil {
 				return nil, err
 			}
-			
+
 			index[id] = append(index[id], sibling)
 		}
 	}

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -100,9 +100,6 @@ var _ = Describe("Workload controller", func() {
 	})
 
 	It("should add all Pods from same workload with same image as CIS owners", func() {
-		const FirstSHA = "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f"
-		const SecondSHA = "sha256:45dddaa9b519329a688366e2b6119214a42cac569529ccacb0989c43355f0255"
-
 		newReplicaset := func(name string) *appsv1.ReplicaSet {
 			rs := &appsv1.ReplicaSet{}
 			rs.Namespace = DefaultNamespaceName
@@ -158,6 +155,8 @@ var _ = Describe("Workload controller", func() {
 		Expect(k8sClient.Create(ctx, rs1)).To(Succeed())
 		Expect(k8sClient.Create(ctx, rs2)).To(Succeed())
 
+		const FirstSHA = "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f"
+		const SecondSHA = "sha256:45dddaa9b519329a688366e2b6119214a42cac569529ccacb0989c43355f0255"
 		pod1 := newPod(rs1, "controlled-1", FirstSHA, "")
 		pod2 := newPod(rs1, "controlled-2", FirstSHA, "")
 		// This pod simulates the ReplicaSet previously having different

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -100,6 +100,9 @@ var _ = Describe("Workload controller", func() {
 	})
 
 	It("should add all Pods from same workload with same image as CIS owners", func() {
+		const FirstSHA = "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f"
+		const SecondSHA = "sha256:45dddaa9b519329a688366e2b6119214a42cac569529ccacb0989c43355f0255"
+
 		newReplicaset := func(name string) *appsv1.ReplicaSet {
 			rs := &appsv1.ReplicaSet{}
 			rs.Namespace = DefaultNamespaceName
@@ -155,14 +158,14 @@ var _ = Describe("Workload controller", func() {
 		Expect(k8sClient.Create(ctx, rs1)).To(Succeed())
 		Expect(k8sClient.Create(ctx, rs2)).To(Succeed())
 
-		pod1 := newPod(rs1, "controlled-1", "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f", "")
-		pod2 := newPod(rs1, "controlled-2", "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f", "")
+		pod1 := newPod(rs1, "controlled-1", FirstSHA, "")
+		pod2 := newPod(rs1, "controlled-2", FirstSHA, "")
 		// This pod simulates the ReplicaSet previously having different
 		// container names. As the Replica set's container names differ in
 		// differnt pods, multiple ContainerImageScans should be created.
-		pod3 := newPod(rs1, "controlled-3", "sha256:10615e4f03bddba4cd49823420d9f50a403776d1b58991caa6d123e3527ff79f", "-old-rs")
-		pod4 := newPod(rs1, "controlled-4", "sha256:45dddaa9b519329a688366e2b6119214a42cac569529ccacb0989c43355f0255", "")
-		pod5 := newPod(rs2, "controlled-5", "sha256:45dddaa9b519329a688366e2b6119214a42cac569529ccacb0989c43355f0255", "")
+		pod3 := newPod(rs1, "controlled-3", FirstSHA, "-old-rs")
+		pod4 := newPod(rs1, "controlled-4", SecondSHA, "")
+		pod5 := newPod(rs2, "controlled-5", SecondSHA, "")
 
 		Expect(k8sClient.Create(ctx, pod1.DeepCopy())).To(Succeed())
 		Expect(k8sClient.Create(ctx, pod2.DeepCopy())).To(Succeed())

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -20,6 +20,8 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
+const DefaultNamespaceName = "default"
+
 type TestWorkloadFactory func(namespacedName types.NamespacedName, labels map[string]string) client.Object
 
 var _ = Describe("Workload controller", func() {
@@ -69,7 +71,7 @@ var _ = Describe("Workload controller", func() {
 
 	It("should pick up ignore-unfixed annotation from workload", func() {
 		pod := &corev1.Pod{}
-		pod.Namespace = "default"
+		pod.Namespace = DefaultNamespaceName
 		pod.Name = "ignore-unfixed"
 		pod.Annotations = map[string]string{"image-scanner.statnett.no/ignore-unfixed": "true"}
 		pod.Labels = map[string]string{"app": "oauth2-proxy"}
@@ -100,7 +102,7 @@ var _ = Describe("Workload controller", func() {
 	It("should add all Pods from same workload with same image as CIS owners", func() {
 		newReplicaset := func(name string) *appsv1.ReplicaSet {
 			rs := &appsv1.ReplicaSet{}
-			rs.Namespace = "default"
+			rs.Namespace = DefaultNamespaceName
 			rs.Name = name
 			rs.Spec.Template.Labels = map[string]string{"app": name, "test": "controller"}
 			rs.Spec.Template.Spec.Containers = []corev1.Container{
@@ -210,7 +212,7 @@ var _ = Describe("Workload controller", func() {
 
 	It("should delete obsolete ContainerImageScan", func() {
 		pod := &corev1.Pod{}
-		pod.Namespace = "default"
+		pod.Namespace = DefaultNamespaceName
 		pod.Name = "crashing-pod"
 		pod.Labels = map[string]string{"app": "crashing-pod"}
 		pod.Spec.Containers = []corev1.Container{

--- a/internal/controller/stas/workload_controller_test.go
+++ b/internal/controller/stas/workload_controller_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Workload controller", func() {
 			), timeout, interval,
 		).Should(WithTransform(ownerRefTransform, Equal([][]types.UID{
 			{pod4.UID},
-			{pod1.UID, pod2.UID}, // 2 and not 3 due to pod3 having different container names
+			{pod1.UID, pod2.UID}, // Not pod3 due to it having different container names
 			{pod3.UID},
 			{pod4.UID},
 			{pod1.UID, pod2.UID},


### PR DESCRIPTION
Simplifies migration to server side apply. Can now safely overwrite (not merge) container image scan owner referances