### PR TITLE
fix: move mount of trivy binary to /run/image-scanner/trivy

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,8 +11,7 @@ configMapGenerator:
     namespace: image-scanner
     literals:
       - SERVER=http://trivy.image-scanner.svc.cluster.local
-      # FIXME: The second skip path is needed since Trivy somehow removes leading parts from the actual path
-      - SKIP_FILES=/var/run/image-scanner/trivy,run/image-scanner/trivy
+      - SKIP_FILES=/run/image-scanner/trivy
       - TIMEOUT=30m
 generatorOptions:
   disableNameSuffixHash: true

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -51,7 +51,7 @@ spec:
             - rootfs
             - /
           command:
-            - /var/run/image-scanner/trivy
+            - /run/image-scanner/trivy
           env:
             - name: HOME
               value: /tmp
@@ -90,7 +90,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-            - mountPath: /var/run/image-scanner
+            - mountPath: /run/image-scanner
               name: image-scanner
             - mountPath: /tmp
               name: tmp
@@ -101,7 +101,7 @@ spec:
             - cp
             - -v
             - /usr/local/bin/trivy
-            - /var/run/image-scanner/trivy
+            - /run/image-scanner/trivy
           image: aquasecurity/trivy
           imagePullPolicy: IfNotPresent
           name: trivy
@@ -115,7 +115,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-            - mountPath: /var/run/image-scanner
+            - mountPath: /run/image-scanner
               name: image-scanner
       restartPolicy: OnFailure
       schedulerName: default-scheduler

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	FsScanSharedVolumeMountPath   = "/var/run/image-scanner"
+	FsScanSharedVolumeMountPath   = "/run/image-scanner"
 	FsScanSharedVolumeName        = "image-scanner"
 	FsScanTrivyBinaryPath         = FsScanSharedVolumeMountPath + "/trivy"
 	JobNameSpecHashPartLength     = 5


### PR DESCRIPTION
This should resolve the malfunctioning skip-files configuration causing trivy binary vulnerabilities to show up in user scan reports.