### PR TITLE
feat: opt-in creating wg-policy PolicyReport

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ func main() {
 	}
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	config.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 	pflag.Parse()
 
 	logger := zap.New(zap.UseFlagOptions(&opts))

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
+	k8s.io/component-base v0.30.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/cli-utils v0.37.2
@@ -29,6 +30,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -231,6 +233,8 @@ k8s.io/apimachinery v0.30.3 h1:q1laaWCmrszyQuSQCfNB8cFgCuDAoPszKY4ucAjDwHc=
 k8s.io/apimachinery v0.30.3/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
 k8s.io/client-go v0.30.3 h1:bHrJu3xQZNXIi8/MoxYtZBBWQQXwy16zqJwloXXfD3k=
 k8s.io/client-go v0.30.3/go.mod h1:8d4pf8vYu665/kUbsxWAQ/JDBNWqfFeZnvFiVdmx89U=
+k8s.io/component-base v0.30.3 h1:Ci0UqKWf4oiwy8hr1+E3dsnliKnkMLZMVbWzeorlk7s=
+k8s.io/component-base v0.30.3/go.mod h1:C1SshT3rGPCuNtBs14RmVD2xW0EhRSeLvBh7AGk1quA=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7FjZpUb45WallggurYhKGag=

--- a/internal/config/feature/feature.go
+++ b/internal/config/feature/feature.go
@@ -1,0 +1,19 @@
+package feature
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+
+	"github.com/statnett/image-scanner-operator/internal/config"
+)
+
+// PolicyReport will ensure PolicyReport resources are created for completed scan jobs.
+const PolicyReport featuregate.Feature = "PolicyReport"
+
+func init() {
+	runtime.Must(config.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	PolicyReport: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/internal/config/feature_gate.go
+++ b/internal/config/feature_gate.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+	// DefaultMutableFeatureGate is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup should make use of this.
+	DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// DefaultFeatureGate is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this feature gate should use DefaultMutableFeatureGate.
+	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
+)

--- a/internal/controller/stas/containerimagescan_status.go
+++ b/internal/controller/stas/containerimagescan_status.go
@@ -71,7 +71,7 @@ func (p *containerImageScanStatusPatch) withScanJob(job *batchv1.Job, successful
 	return p
 }
 
-func (p *containerImageScanStatusPatch) withResults(vulnerabilities []stasv1alpha1.Vulnerability, minSeverity stasv1alpha1.Severity) *containerImageScanStatusPatch {
+func (p *containerImageScanStatusPatch) withResults(vulnerabilities []stasv1alpha1.Vulnerability, summary *stasv1alpha1.VulnerabilitySummary, minSeverity stasv1alpha1.Severity) *containerImageScanStatusPatch {
 	p.minSeverity = &minSeverity
 
 	p.patch.Status.Vulnerabilities = make([]stasv1alpha1ac.VulnerabilityApplyConfiguration, len(vulnerabilities))
@@ -79,7 +79,6 @@ func (p *containerImageScanStatusPatch) withResults(vulnerabilities []stasv1alph
 		p.patch.Status.Vulnerabilities[i] = *vulnerabilityPatch(v)
 	}
 
-	summary := vulnerabilitySummary(vulnerabilities, minSeverity)
 	p.patch.Status.
 		WithVulnerabilitySummary(stasv1alpha1ac.VulnerabilitySummary().
 			WithSeverityCount(summary.SeverityCount).

--- a/internal/controller/stas/policy_report.go
+++ b/internal/controller/stas/policy_report.go
@@ -1,0 +1,128 @@
+package stas
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	policyv1alpha2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
+
+	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
+	policyv1alpha2ac "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2"
+)
+
+func newPolicyReportPatch(cis *stasv1alpha1.ContainerImageScan) *policyReportPatch {
+	return &policyReportPatch{
+		cis: cis,
+		patch: policyv1alpha2ac.PolicyReport(cis.Name, cis.Namespace).
+			WithScope(
+				corev1.ObjectReference{
+					Kind: cis.Spec.Workload.Kind,
+					Name: cis.Spec.Workload.Name,
+				},
+			),
+	}
+}
+
+type policyReportPatch struct {
+	cis             *stasv1alpha1.ContainerImageScan
+	patch           *policyv1alpha2ac.PolicyReportApplyConfiguration
+	vulnerabilities []stasv1alpha1.Vulnerability
+	minSeverity     stasv1alpha1.Severity
+}
+
+func (p *policyReportPatch) withResults(vulnerabilities []stasv1alpha1.Vulnerability, summary *stasv1alpha1.VulnerabilitySummary, minSeverity stasv1alpha1.Severity) *policyReportPatch {
+	p.vulnerabilities = vulnerabilities
+	p.minSeverity = minSeverity
+
+	p.patch.
+		WithSummary(policyv1alpha2ac.PolicyReportSummary().
+			WithSkip(int(summary.SeverityCount[stasv1alpha1.SeverityUnknown.String()])).
+			WithWarn(int(summary.SeverityCount[stasv1alpha1.SeverityLow.String()] + summary.SeverityCount[stasv1alpha1.SeverityMedium.String()])).
+			WithFail(int(summary.SeverityCount[stasv1alpha1.SeverityHigh.String()] + summary.SeverityCount[stasv1alpha1.SeverityCritical.String()])))
+
+	return p
+}
+
+func (p *policyReportPatch) apply(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
+	if err := SetControllerReference(p.cis, p.patch.ObjectMetaApplyConfiguration, scheme); err != nil {
+		return err
+	}
+
+	report := &policyv1alpha2.PolicyReport{}
+	report.Name = *p.patch.Name
+	report.Namespace = *p.patch.Namespace
+
+	var err error
+	// Repeat until resource fits in api-server by increasing minimum severity on failure.
+	for severity := p.minSeverity; severity <= stasv1alpha1.MaxSeverity; severity++ {
+		p.vulnerabilities = slices.DeleteFunc(p.vulnerabilities, func(v stasv1alpha1.Vulnerability) bool {
+			return v.Severity < severity
+		})
+
+		p.patch.Results = make([]policyv1alpha2ac.PolicyReportResultApplyConfiguration, len(p.vulnerabilities))
+		for i, v := range p.vulnerabilities {
+			p.patch.Results[i] = *policyReportResultPatch(v)
+		}
+
+		err = c.Patch(ctx, report, applyPatch{p.patch}, FieldValidationStrict, client.ForceOwnership, fieldOwner)
+		if !isResourceTooLargeError(err) {
+			break
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("when applying policy report: %w", err)
+	}
+
+	return nil
+}
+
+func policyReportResultPatch(v stasv1alpha1.Vulnerability) *policyv1alpha2ac.PolicyReportResultApplyConfiguration {
+	properties := map[string]string{
+		"pkgName":          v.PkgName,
+		"pkgPath":          v.PkgPath,
+		"installedVersion": v.InstalledVersion,
+		"fixedVersion":     v.FixedVersion,
+		"primaryURL":       v.PrimaryURL,
+	}
+
+	// Remove properties with empty values to compact report
+	maps.DeleteFunc(properties, func(k string, v string) bool {
+		return len(v) == 0
+	})
+
+	return policyv1alpha2ac.PolicyReportResult().
+		WithCategory("vulnerability scan").
+		WithSource("image-scanner").
+		WithPolicy(v.VulnerabilityID).
+		WithResult(severityToPolicyResult(v.Severity)).
+		WithSeverity(severityToPolicyResultSeverity(v.Severity)).
+		WithDescription(v.Title).
+		WithProperties(properties)
+}
+
+func severityToPolicyResultSeverity(severity stasv1alpha1.Severity) policyv1alpha2.PolicyResultSeverity {
+	switch severity {
+	case stasv1alpha1.SeverityUnknown:
+		return ""
+	default:
+		return policyv1alpha2.PolicyResultSeverity(strings.ToLower(severity.String()))
+	}
+}
+
+func severityToPolicyResult(severity stasv1alpha1.Severity) policyv1alpha2.PolicyResult {
+	switch severity {
+	case stasv1alpha1.SeverityUnknown:
+		return "skip"
+	case stasv1alpha1.SeverityLow, stasv1alpha1.SeverityMedium:
+		return "warn"
+	default:
+		return "fail"
+	}
+}

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -26,9 +26,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	policyv1alpha2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
+	"github.com/statnett/image-scanner-operator/internal/config/feature"
 	"github.com/statnett/image-scanner-operator/internal/pod"
 )
 
@@ -61,9 +63,14 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(context.TODO())
 
+	Expect(config.DefaultMutableFeatureGate.OverrideDefault(feature.PolicyReport, true)).To(Succeed())
+
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "config", "wg-policy", "crd"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -76,7 +83,7 @@ var _ = BeforeSuite(func() {
 	Expect(appsv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(stasv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(batchv1.AddToScheme(scheme.Scheme)).To(Succeed())
-	//+kubebuilder:scaffold:scheme
+	Expect(policyv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	policyv1alpha2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
@@ -39,9 +40,8 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	//+kubebuilder:scaffold:scheme
 	utilruntime.Must(stasv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(policyv1alpha2.AddToScheme(scheme))
 }
 
 type Operator struct{}


### PR DESCRIPTION
This PR adds our first feature gate! 🎉 The feature gate is currently disabled by default. If the feature gate is enabled, the operator will create [wgpolicyk8s.io/v1alpha2 PolicyReport](https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml) resources for completed scan jobs.

The proposed mapping from the Trivy scan results to the policy report is inspired by [trivy-operator-polr-adapter](https://github.com/fjogeleit/trivy-operator-polr-adapter/blob/main/pkg/adapters/vulnr/mapper.go).

The Kubernetes policy working group has defined newer/improved PolicyReport APIs, but the proposed group/version is currently used, and CRD is installed, by Kyverno (version 1.12.5). The API is also the only API currently supported by [policy-reporter](https://github.com/kyverno/policy-reporter) - making the choice rather simple. I have filed an issue to support newer APIs, https://github.com/kyverno/policy-reporter/issues/461, but the suggested API seems like our best choice now.

Tests of this new opt-in is currently limited, and we should probably also add some docs to indicate that the feature is there and how it is supposed to be used. I hope to do this in a follow-up PR.