### PR TITLE
test: bump K8s envTest and k3s versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= "registry.dummy-domain.com/image-scanner/controller:dev"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28.0
+ENVTEST_K8S_VERSION = 1.30.0
 # Namespace to install operator into
 K8S_NAMESPACE ?= image-scanner
 

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -18,8 +18,10 @@ spec:
   backoffLimit: 3
   completionMode: NonIndexed
   completions: 1
+  manualSelector: false
   parallelism: 1
   suspend: false
+  podReplacementPolicy: TerminatingOrFailed
   template:
     metadata:
       labels:

--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -3,5 +3,5 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: image-scanner
-# renovate-image: versioning=regex:v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<compatibility>k3s)(?<build>\d+)(\s|$)
-image: docker.io/rancher/k3s:v1.28.2-k3s1
+# renovate-image:
+image: docker.io/rancher/k3s:v1.30.2-k3s2


### PR DESCRIPTION
I'm having issues running tests from my IDE, and it seems like the problem is that my IDE finds a locally installed version of K8s envTest (1.30). To mend this, I suggest upgrading to the latest version in CI. This makes `make test` behave as in my IDE.

I also noticed that the k3s version was outdated, so it's also fixed in this PR. I suspect an invalid Renovate expression to be the culprit, so trying with a major simplification that I know works for other images.