### PR TITLE
fix: add missing PolicyReport RBAC

### DIFF
--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../default
+  - ../wg-policy
 configMapGenerator:
   - name: image-scanner-config
     behavior: merge
@@ -10,6 +11,13 @@ configMapGenerator:
       # Only include chainsaw namespace pattern to reduce resource waste running e2e tests
       - SCAN_NAMESPACE_INCLUDE_REGEXP=^chainsaw-.*
 patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --feature-gates=PolicyReport=true
+    target:
+      kind: Deployment
+      name: image-scanner-controller-manager
   # FIXME: Somehow sessionAffinity does not work when running e2e tests in some environments
   # Disable trivy server sessionAffinity; not really needed when running a single replica
   - patch: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - wgpolicyk8s.io
+  resources:
+  - policyreports
+  verbs:
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,6 +108,7 @@ rules:
   - policyreports
   verbs:
   - create
+  - delete
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -107,6 +107,7 @@ rules:
   resources:
   - policyreports
   verbs:
+  - create
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/wg-policy/crd/kustomization.yaml
+++ b/config/wg-policy/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - reports.x-k8s.io_clusterpolicyreports.yaml
-  - reports.x-k8s.io_policyreports.yaml
-  - wgpolicyk8s.io_clusterpolicyreports.yaml
+  # - reports.x-k8s.io_clusterpolicyreports.yaml
+  # - reports.x-k8s.io_policyreports.yaml
+  # - wgpolicyk8s.io_clusterpolicyreports.yaml
   - wgpolicyk8s.io_policyreports.yaml

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -51,7 +51,10 @@ type ScanJobReconciler struct {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
-//+kubebuilder:rbac:groups="wgpolicyk8s.io",resources=policyreports,verbs=create;patch
+// Must add policyreports delete verb and containerimagescans/finalizers update verb to satisfy
+// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+//+kubebuilder:rbac:groups="wgpolicyk8s.io",resources=policyreports,verbs=create;patch;delete
+//+kubebuilder:rbac:groups=stas.statnett.no,resources=containerimagescans/finalizers,verbs=update
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -51,6 +51,7 @@ type ScanJobReconciler struct {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
+//+kubebuilder:rbac:groups="wgpolicyk8s.io",resources=policyreports,verbs=patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -51,7 +51,7 @@ type ScanJobReconciler struct {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch,namespace=image-scanner
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list,namespace=image-scanner
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch
-//+kubebuilder:rbac:groups="wgpolicyk8s.io",resources=policyreports,verbs=patch
+//+kubebuilder:rbac:groups="wgpolicyk8s.io",resources=policyreports,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/test/e2e/scenario/policy-report/00-assert.yaml
+++ b/test/e2e/scenario/policy-report/00-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: stas.statnett.no/v1alpha1
+kind: ContainerImageScan
+metadata:
+  name: pod-echo-app-ab50d
+spec:
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
+  name: docker.io/nginxinc/nginx-unprivileged
+  workload:
+    containerName: app
+    kind: Pod
+    name: echo

--- a/test/e2e/scenario/policy-report/00-create.yaml
+++ b/test/e2e/scenario/policy-report/00-create.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo
+  labels:
+    app.kubernetes.io/name: echo
+spec:
+  containers:
+    - name: app
+      # Using image digest to avoid fragile tests
+      image: >-
+        docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
+      ports:
+        - name: app
+          containerPort: 8080
+          protocol: TCP

--- a/test/e2e/scenario/policy-report/01-assert.yaml
+++ b/test/e2e/scenario/policy-report/01-assert.yaml
@@ -3,7 +3,6 @@ apiVersion: wgpolicyk8s.io/v1alpha2
 kind: PolicyReport
 metadata:
   name: pod-echo-app-ab50d
-  namespace: egb-test
   ownerReferences:
     - apiVersion: stas.statnett.no/v1alpha1
       blockOwnerDeletion: true

--- a/test/e2e/scenario/policy-report/01-assert.yaml
+++ b/test/e2e/scenario/policy-report/01-assert.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: wgpolicyk8s.io/v1alpha2
+kind: PolicyReport
+metadata:
+  name: pod-echo-app-ab50d
+  namespace: egb-test
+  ownerReferences:
+    - apiVersion: stas.statnett.no/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ContainerImageScan
+      name: pod-echo-app-ab50d
+scope:
+  kind: Pod
+  name: echo

--- a/test/e2e/scenario/policy-report/chainsaw-test.yaml
+++ b/test/e2e/scenario/policy-report/chainsaw-test.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: scan-pod
+spec:
+  steps:
+    - name: step-00
+      try:
+        - apply:
+            file: 00-create.yaml
+        - assert:
+            file: 00-assert.yaml
+    - name: step-01
+      try:
+        - assert:
+            file: 01-assert.yaml

--- a/test/e2e/scenario/policy-report/chainsaw-test.yaml
+++ b/test/e2e/scenario/policy-report/chainsaw-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: scan-pod
+  name: policy-report
 spec:
   steps:
     - name: step-00


### PR DESCRIPTION
When trying out the new PolicyReport feature gate, we discovered that the required RBAC wasn't granted. This PR fixes this and also adds a simple e2e-test verifying that the feature gate works.