### PR TITLE
test(e2e): migrate k3d config to latest version

### DIFF
--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: k3d.io/v1alpha4
+apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: image-scanner


### PR DESCRIPTION
While debugging another issue, I noticed that k3d complained about using outdated config.