### PR TITLE
test(e2e): migrate chainsaw config to latest version

### DIFF
--- a/test/e2e-config/.chainsaw.yaml
+++ b/test/e2e-config/.chainsaw.yaml
@@ -1,10 +1,15 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha2.json
+apiVersion: chainsaw.kyverno.io/v1alpha2
 kind: Configuration
 metadata:
   name: default
 spec:
-  reportFormat: XML
+  cleanup:
+    # Might be set to true to debug test resources
+    skipDelete: false
+  report:
+    format: XML
+    name: chainsaw-report
   timeouts:
     apply: 4m0s
     assert: 4m0s


### PR DESCRIPTION
While debugging another issue, I noticed that we are not using the latest Chainsaw config version.