### PR TITLE
test(e2e): make chainsaw really assert status

### DIFF
--- a/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
+++ b/test/e2e/scenario/vulnerability-overflow/00-assert.yaml
@@ -7,4 +7,4 @@ spec:
   name: docker.io/kennship/http-echo
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/scenario_disabled/private-image/00-assert.yaml
+++ b/test/e2e/scenario_disabled/private-image/00-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: ghcr.io/statnett/http-https-echo-internal
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-deployment/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-deployment/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-job/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-pod/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-pod/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true

--- a/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
@@ -8,4 +8,4 @@ spec:
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:
-    severityCount: {}
+    (severityCount != null): true


### PR DESCRIPTION
It turns out that chainsaw doesn't read the assert resources as kuttl did, so we have been running without asserting tests since https://github.com/statnett/image-scanner-operator/pull/794. 😆 

@eddycharly is fixing this issue in chainsaw now, but until a new release of chainsaw is available, this PR implements a [workaround suggested on Slack](https://kubernetes.slack.com/archives/C067LUFL43U/p1721574298810959?thread_ts=1721566440.213909&cid=C067LUFL43U).