### PR TITLE
test(e2e): refresh nginx test image

### DIFF
--- a/test/e2e/workload-scan/scan-cron-job/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: cronjob-echo-app-94a2e
+  name: cronjob-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-cron-job/00-create.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/00-create.yaml
@@ -15,7 +15,7 @@ spec:
             - name: app
               # Using image digest to avoid fragile tests
               image: >-
-                docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+                docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
               command:
                 - sleep
                 - 10s

--- a/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-cron-job/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: cronjob-echo-app-94a2e
+  name: cronjob-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-daemon-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: daemonset-echo-app-94a2e
+  name: daemonset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-daemon-set/00-create.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/00-create.yaml
@@ -18,7 +18,7 @@ spec:
         - name: app
           # Using image digest to avoid fragile tests
           image: >-
-            docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+            docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
           ports:
             - name: app
               containerPort: 8080

--- a/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-daemon-set/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: daemonset-echo-app-94a2e
+  name: daemonset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-deployment/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-deployment/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-echo-app-94a2e
+  name: deployment-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-deployment/00-create.yaml
+++ b/test/e2e/workload-scan/scan-deployment/00-create.yaml
@@ -18,7 +18,7 @@ spec:
         - name: app
           # Using image digest to avoid fragile tests
           image: >-
-            docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+            docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
           ports:
             - name: app
               containerPort: 8080

--- a/test/e2e/workload-scan/scan-deployment/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-deployment/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: deployment-echo-app-94a2e
+  name: deployment-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-job/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-job/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: job-echo-app-94a2e
+  name: job-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-job/00-create.yaml
+++ b/test/e2e/workload-scan/scan-job/00-create.yaml
@@ -12,7 +12,7 @@ spec:
         - name: app
           # Using image digest to avoid fragile tests
           image: >-
-            docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+            docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
           command:
             - sleep
             - 10s

--- a/test/e2e/workload-scan/scan-job/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-job/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: job-echo-app-94a2e
+  name: job-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-pod/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-pod/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: pod-echo-app-94a2e
+  name: pod-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-pod/00-create.yaml
+++ b/test/e2e/workload-scan/scan-pod/00-create.yaml
@@ -10,7 +10,7 @@ spec:
     - name: app
       # Using image digest to avoid fragile tests
       image: >-
-        docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+        docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
       ports:
         - name: app
           containerPort: 8080

--- a/test/e2e/workload-scan/scan-pod/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-pod/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: pod-echo-app-94a2e
+  name: pod-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-replica-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: replicaset-echo-app-94a2e
+  name: replicaset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-replica-set/00-create.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/00-create.yaml
@@ -18,7 +18,7 @@ spec:
         - name: app
           # Using image digest to avoid fragile tests
           image: >-
-            docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+            docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
           ports:
             - name: app
               containerPort: 8080

--- a/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-replica-set/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: replicaset-echo-app-94a2e
+  name: replicaset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:

--- a/test/e2e/workload-scan/scan-stateful-set/00-assert.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/00-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: statefulset-echo-app-94a2e
+  name: statefulset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
   workload:
     containerName: app

--- a/test/e2e/workload-scan/scan-stateful-set/00-create.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/00-create.yaml
@@ -19,7 +19,7 @@ spec:
         - name: app
           # Using image digest to avoid fragile tests
           image: >-
-            docker.io/nginxinc/nginx-unprivileged@sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4
+            docker.io/nginxinc/nginx-unprivileged@sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191
           ports:
             - name: app
               containerPort: 8080

--- a/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
+++ b/test/e2e/workload-scan/scan-stateful-set/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: stas.statnett.no/v1alpha1
 kind: ContainerImageScan
 metadata:
-  name: statefulset-echo-app-94a2e
+  name: statefulset-echo-app-ab50d
 spec:
-  digest: 'sha256:6da1811b094adbea1eb34c3e48fc2833b1a11a351ec7b36cc390e740a64fbae4'
+  digest: 'sha256:1645798310a56491acb75d750ed6a4693a35506c9860503d21a877cc54d95191'
   name: docker.io/nginxinc/nginx-unprivileged
 status:
   vulnerabilitySummary:


### PR DESCRIPTION
It seems like we are using an old nginx image with a lot of vulnerabilities. This PR bumps the image to the digest of the current latest tag.