### PR TITLE
chore: consistent Dockerfile casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa as builder
+FROM docker.io/library/golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS builder
 ARG GOPROXY
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Observed a warning in another PR: https://github.com/statnett/image-scanner-operator/pull/1041/files