### PR TITLE
fix(deps): bump K8s dependencies to 0.31.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,9 +195,9 @@ GCI_VERSION ?= v0.13.4
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.3
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
-CODE_GENERATOR_VERSION ?= v0.30.3
+CODE_GENERATOR_VERSION ?= v0.31.0
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools
-CONTROLLER_TOOLS_VERSION ?= v0.15.0
+CONTROLLER_TOOLS_VERSION ?= v0.16.0
 
 .PHONY: applyconfiguration-gen
 applyconfiguration-gen: $(APPLYCONFIGURATION_GEN) ## Download applyconfiguration-gen locally if necessary.

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: containerimagescans.stas.statnett.no
 spec:
   group: stas.statnett.no
@@ -57,8 +57,8 @@ spec:
                 description: "Digest allows simple protection of hex formatted digest
                   strings, prefixed\nby their algorithm. Strings of type Digest have
                   some guarantee of being in\nthe correct format and it provides quick
-                  access to the components of a\ndigest string.\n\n\nThe following
-                  is an example of the contents of Digest types:\n\n\n\tsha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc\n\n\nThis
+                  access to the components of a\ndigest string.\n\nThe following is
+                  an example of the contents of Digest types:\n\n\tsha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc\n\nThis
                   allows to abstract the digest behind this type and work only in
                   those\nterms."
                 type: string
@@ -109,16 +109,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of an object's state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -159,12 +151,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,13 +8,6 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - replicationcontrollers
   verbs:
   - get
@@ -24,29 +17,8 @@ rules:
   - apps
   resources:
   - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - get
@@ -56,13 +28,6 @@ rules:
   - batch
   resources:
   - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
   - jobs
   verbs:
   - get

--- a/internal/client/applyconfiguration/stas/v1alpha1/containerimagescan.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/containerimagescan.go
@@ -8,7 +8,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ContainerImageScanApplyConfiguration represents an declarative configuration of the ContainerImageScan type for use
+// ContainerImageScanApplyConfiguration represents a declarative configuration of the ContainerImageScan type for use
 // with apply.
 type ContainerImageScanApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -17,7 +17,7 @@ type ContainerImageScanApplyConfiguration struct {
 	Status                           *ContainerImageScanStatusApplyConfiguration `json:"status,omitempty"`
 }
 
-// ContainerImageScan constructs an declarative configuration of the ContainerImageScan type for use with
+// ContainerImageScan constructs a declarative configuration of the ContainerImageScan type for use with
 // apply.
 func ContainerImageScan(name, namespace string) *ContainerImageScanApplyConfiguration {
 	b := &ContainerImageScanApplyConfiguration{}
@@ -200,4 +200,10 @@ func (b *ContainerImageScanApplyConfiguration) WithSpec(value *ContainerImageSca
 func (b *ContainerImageScanApplyConfiguration) WithStatus(value *ContainerImageScanStatusApplyConfiguration) *ContainerImageScanApplyConfiguration {
 	b.Status = value
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *ContainerImageScanApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanspec.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanspec.go
@@ -7,7 +7,7 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-// ContainerImageScanSpecApplyConfiguration represents an declarative configuration of the ContainerImageScanSpec type for use
+// ContainerImageScanSpecApplyConfiguration represents a declarative configuration of the ContainerImageScanSpec type for use
 // with apply.
 type ContainerImageScanSpecApplyConfiguration struct {
 	ImageScanSpecApplyConfiguration `json:",inline"`
@@ -15,7 +15,7 @@ type ContainerImageScanSpecApplyConfiguration struct {
 	Workload                        *WorkloadApplyConfiguration `json:"workload,omitempty"`
 }
 
-// ContainerImageScanSpecApplyConfiguration constructs an declarative configuration of the ContainerImageScanSpec type for use with
+// ContainerImageScanSpecApplyConfiguration constructs a declarative configuration of the ContainerImageScanSpec type for use with
 // apply.
 func ContainerImageScanSpec() *ContainerImageScanSpecApplyConfiguration {
 	return &ContainerImageScanSpecApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanstatus.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/containerimagescanstatus.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ContainerImageScanStatusApplyConfiguration represents an declarative configuration of the ContainerImageScanStatus type for use
+// ContainerImageScanStatusApplyConfiguration represents a declarative configuration of the ContainerImageScanStatus type for use
 // with apply.
 type ContainerImageScanStatusApplyConfiguration struct {
 	ObservedGeneration     *int64                                  `json:"observedGeneration,omitempty"`
@@ -20,7 +20,7 @@ type ContainerImageScanStatusApplyConfiguration struct {
 	VulnerabilitySummary   *VulnerabilitySummaryApplyConfiguration `json:"vulnerabilitySummary,omitempty"`
 }
 
-// ContainerImageScanStatusApplyConfiguration constructs an declarative configuration of the ContainerImageScanStatus type for use with
+// ContainerImageScanStatusApplyConfiguration constructs a declarative configuration of the ContainerImageScanStatus type for use with
 // apply.
 func ContainerImageScanStatus() *ContainerImageScanStatusApplyConfiguration {
 	return &ContainerImageScanStatusApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/image.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/image.go
@@ -6,14 +6,14 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 )
 
-// ImageApplyConfiguration represents an declarative configuration of the Image type for use
+// ImageApplyConfiguration represents a declarative configuration of the Image type for use
 // with apply.
 type ImageApplyConfiguration struct {
 	Name   *string          `json:"name,omitempty"`
 	Digest *godigest.Digest `json:"digest,omitempty"`
 }
 
-// ImageApplyConfiguration constructs an declarative configuration of the Image type for use with
+// ImageApplyConfiguration constructs a declarative configuration of the Image type for use with
 // apply.
 func Image() *ImageApplyConfiguration {
 	return &ImageApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/imagescanspec.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/imagescanspec.go
@@ -7,14 +7,14 @@ import (
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-// ImageScanSpecApplyConfiguration represents an declarative configuration of the ImageScanSpec type for use
+// ImageScanSpecApplyConfiguration represents a declarative configuration of the ImageScanSpec type for use
 // with apply.
 type ImageScanSpecApplyConfiguration struct {
 	ImageApplyConfiguration      `json:",inline"`
 	ScanConfigApplyConfiguration `json:",inline"`
 }
 
-// ImageScanSpecApplyConfiguration constructs an declarative configuration of the ImageScanSpec type for use with
+// ImageScanSpecApplyConfiguration constructs a declarative configuration of the ImageScanSpec type for use with
 // apply.
 func ImageScanSpec() *ImageScanSpecApplyConfiguration {
 	return &ImageScanSpecApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/scanconfig.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/scanconfig.go
@@ -6,14 +6,14 @@ import (
 	v1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-// ScanConfigApplyConfiguration represents an declarative configuration of the ScanConfig type for use
+// ScanConfigApplyConfiguration represents a declarative configuration of the ScanConfig type for use
 // with apply.
 type ScanConfigApplyConfiguration struct {
 	MinSeverity   *v1alpha1.Severity `json:"minSeverity,omitempty"`
 	IgnoreUnfixed *bool              `json:"ignoreUnfixed,omitempty"`
 }
 
-// ScanConfigApplyConfiguration constructs an declarative configuration of the ScanConfig type for use with
+// ScanConfigApplyConfiguration constructs a declarative configuration of the ScanConfig type for use with
 // apply.
 func ScanConfig() *ScanConfigApplyConfiguration {
 	return &ScanConfigApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/vulnerability.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/vulnerability.go
@@ -6,7 +6,7 @@ import (
 	v1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 )
 
-// VulnerabilityApplyConfiguration represents an declarative configuration of the Vulnerability type for use
+// VulnerabilityApplyConfiguration represents a declarative configuration of the Vulnerability type for use
 // with apply.
 type VulnerabilityApplyConfiguration struct {
 	VulnerabilityID  *string            `json:"vulnerabilityID,omitempty"`
@@ -19,7 +19,7 @@ type VulnerabilityApplyConfiguration struct {
 	PrimaryURL       *string            `json:"primaryURL,omitempty"`
 }
 
-// VulnerabilityApplyConfiguration constructs an declarative configuration of the Vulnerability type for use with
+// VulnerabilityApplyConfiguration constructs a declarative configuration of the Vulnerability type for use with
 // apply.
 func Vulnerability() *VulnerabilityApplyConfiguration {
 	return &VulnerabilityApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/vulnerabilitysummary.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/vulnerabilitysummary.go
@@ -2,7 +2,7 @@
 
 package v1alpha1
 
-// VulnerabilitySummaryApplyConfiguration represents an declarative configuration of the VulnerabilitySummary type for use
+// VulnerabilitySummaryApplyConfiguration represents a declarative configuration of the VulnerabilitySummary type for use
 // with apply.
 type VulnerabilitySummaryApplyConfiguration struct {
 	SeverityCount map[string]int32 `json:"severityCount,omitempty"`
@@ -10,7 +10,7 @@ type VulnerabilitySummaryApplyConfiguration struct {
 	UnfixedCount  *int32           `json:"unfixedCount,omitempty"`
 }
 
-// VulnerabilitySummaryApplyConfiguration constructs an declarative configuration of the VulnerabilitySummary type for use with
+// VulnerabilitySummaryApplyConfiguration constructs a declarative configuration of the VulnerabilitySummary type for use with
 // apply.
 func VulnerabilitySummary() *VulnerabilitySummaryApplyConfiguration {
 	return &VulnerabilitySummaryApplyConfiguration{}

--- a/internal/client/applyconfiguration/stas/v1alpha1/workload.go
+++ b/internal/client/applyconfiguration/stas/v1alpha1/workload.go
@@ -2,7 +2,7 @@
 
 package v1alpha1
 
-// WorkloadApplyConfiguration represents an declarative configuration of the Workload type for use
+// WorkloadApplyConfiguration represents a declarative configuration of the Workload type for use
 // with apply.
 type WorkloadApplyConfiguration struct {
 	Group         *string `json:"group,omitempty"`
@@ -11,7 +11,7 @@ type WorkloadApplyConfiguration struct {
 	ContainerName *string `json:"containerName,omitempty"`
 }
 
-// WorkloadApplyConfiguration constructs an declarative configuration of the Workload type for use with
+// WorkloadApplyConfiguration constructs a declarative configuration of the Workload type for use with
 // apply.
 func Workload() *WorkloadApplyConfiguration {
 	return &WorkloadApplyConfiguration{}

--- a/internal/client/applyconfiguration/utils.go
+++ b/internal/client/applyconfiguration/utils.go
@@ -4,8 +4,11 @@ package applyconfiguration
 
 import (
 	v1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
+	internal "github.com/statnett/image-scanner-operator/internal/client/applyconfiguration/internal"
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/internal/client/applyconfiguration/stas/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
 )
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
@@ -34,4 +37,8 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 
 	}
 	return nil
+}
+
+func NewTypeConverter(scheme *runtime.Scheme) *testing.TypeConverter {
+	return &testing.TypeConverter{Scheme: scheme, TypeResolver: internal.Parser()}
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/clusterpolicyreport.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ClusterPolicyReportApplyConfiguration represents an declarative configuration of the ClusterPolicyReport type for use
+// ClusterPolicyReportApplyConfiguration represents a declarative configuration of the ClusterPolicyReport type for use
 // with apply.
 type ClusterPolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -22,7 +22,7 @@ type ClusterPolicyReportApplyConfiguration struct {
 	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
-// ClusterPolicyReport constructs an declarative configuration of the ClusterPolicyReport type for use with
+// ClusterPolicyReport constructs a declarative configuration of the ClusterPolicyReport type for use with
 // apply.
 func ClusterPolicyReport(name string) *ClusterPolicyReportApplyConfiguration {
 	b := &ClusterPolicyReportApplyConfiguration{}
@@ -241,4 +241,10 @@ func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*PolicyRep
 		b.Results = append(b.Results, *values[i])
 	}
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *ClusterPolicyReportApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/limits.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/limits.go
@@ -6,14 +6,14 @@ import (
 	v1beta2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2"
 )
 
-// LimitsApplyConfiguration represents an declarative configuration of the Limits type for use
+// LimitsApplyConfiguration represents a declarative configuration of the Limits type for use
 // with apply.
 type LimitsApplyConfiguration struct {
 	MaxResults   *int                   `json:"maxResults,omitempty"`
 	StatusFilter []v1beta2.StatusFilter `json:"statusFilter,omitempty"`
 }
 
-// LimitsApplyConfiguration constructs an declarative configuration of the Limits type for use with
+// LimitsApplyConfiguration constructs a declarative configuration of the Limits type for use with
 // apply.
 func Limits() *LimitsApplyConfiguration {
 	return &LimitsApplyConfiguration{}

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreport.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// PolicyReportApplyConfiguration represents an declarative configuration of the PolicyReport type for use
+// PolicyReportApplyConfiguration represents a declarative configuration of the PolicyReport type for use
 // with apply.
 type PolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -22,7 +22,7 @@ type PolicyReportApplyConfiguration struct {
 	Results                          []PolicyReportResultApplyConfiguration       `json:"results,omitempty"`
 }
 
-// PolicyReport constructs an declarative configuration of the PolicyReport type for use with
+// PolicyReport constructs a declarative configuration of the PolicyReport type for use with
 // apply.
 func PolicyReport(name, namespace string) *PolicyReportApplyConfiguration {
 	b := &PolicyReportApplyConfiguration{}
@@ -242,4 +242,10 @@ func (b *PolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResu
 		b.Results = append(b.Results, *values[i])
 	}
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *PolicyReportApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportconfiguration.go
@@ -2,13 +2,13 @@
 
 package v1beta2
 
-// PolicyReportConfigurationApplyConfiguration represents an declarative configuration of the PolicyReportConfiguration type for use
+// PolicyReportConfigurationApplyConfiguration represents a declarative configuration of the PolicyReportConfiguration type for use
 // with apply.
 type PolicyReportConfigurationApplyConfiguration struct {
 	Limits *LimitsApplyConfiguration `json:"limits,omitempty"`
 }
 
-// PolicyReportConfigurationApplyConfiguration constructs an declarative configuration of the PolicyReportConfiguration type for use with
+// PolicyReportConfigurationApplyConfiguration constructs a declarative configuration of the PolicyReportConfiguration type for use with
 // apply.
 func PolicyReportConfiguration() *PolicyReportConfigurationApplyConfiguration {
 	return &PolicyReportConfigurationApplyConfiguration{}

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportresult.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportresult.go
@@ -9,7 +9,7 @@ import (
 	v1beta2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2"
 )
 
-// PolicyReportResultApplyConfiguration represents an declarative configuration of the PolicyReportResult type for use
+// PolicyReportResultApplyConfiguration represents a declarative configuration of the PolicyReportResult type for use
 // with apply.
 type PolicyReportResultApplyConfiguration struct {
 	Source           *string                                 `json:"source,omitempty"`
@@ -26,7 +26,7 @@ type PolicyReportResultApplyConfiguration struct {
 	Properties       map[string]string                       `json:"properties,omitempty"`
 }
 
-// PolicyReportResultApplyConfiguration constructs an declarative configuration of the PolicyReportResult type for use with
+// PolicyReportResultApplyConfiguration constructs a declarative configuration of the PolicyReportResult type for use with
 // apply.
 func PolicyReportResult() *PolicyReportResultApplyConfiguration {
 	return &PolicyReportResultApplyConfiguration{}

--- a/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportsummary.go
+++ b/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2/policyreportsummary.go
@@ -2,7 +2,7 @@
 
 package v1beta2
 
-// PolicyReportSummaryApplyConfiguration represents an declarative configuration of the PolicyReportSummary type for use
+// PolicyReportSummaryApplyConfiguration represents a declarative configuration of the PolicyReportSummary type for use
 // with apply.
 type PolicyReportSummaryApplyConfiguration struct {
 	Pass  *int `json:"pass,omitempty"`
@@ -12,7 +12,7 @@ type PolicyReportSummaryApplyConfiguration struct {
 	Skip  *int `json:"skip,omitempty"`
 }
 
-// PolicyReportSummaryApplyConfiguration constructs an declarative configuration of the PolicyReportSummary type for use with
+// PolicyReportSummaryApplyConfiguration constructs a declarative configuration of the PolicyReportSummary type for use with
 // apply.
 func PolicyReportSummary() *PolicyReportSummaryApplyConfiguration {
 	return &PolicyReportSummaryApplyConfiguration{}

--- a/internal/wg-policy/applyconfiguration/utils.go
+++ b/internal/wg-policy/applyconfiguration/utils.go
@@ -3,9 +3,12 @@
 package applyconfiguration
 
 import (
+	internal "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/internal"
 	reportsxk8siov1beta2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/reports.x-k8s.io/v1beta2"
 	wgpolicyk8siov1alpha2 "github.com/statnett/image-scanner-operator/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
 	v1beta2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/reports.x-k8s.io/v1beta2"
 	v1alpha2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
@@ -40,4 +43,8 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 
 	}
 	return nil
+}
+
+func NewTypeConverter(scheme *runtime.Scheme) *testing.TypeConverter {
+	return &testing.TypeConverter{Scheme: scheme, TypeResolver: internal.Parser()}
 }

--- a/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/clusterpolicyreport.go
+++ b/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/clusterpolicyreport.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// ClusterPolicyReportApplyConfiguration represents an declarative configuration of the ClusterPolicyReport type for use
+// ClusterPolicyReportApplyConfiguration represents a declarative configuration of the ClusterPolicyReport type for use
 // with apply.
 type ClusterPolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -20,7 +20,7 @@ type ClusterPolicyReportApplyConfiguration struct {
 	Results                          []PolicyReportResultApplyConfiguration `json:"results,omitempty"`
 }
 
-// ClusterPolicyReport constructs an declarative configuration of the ClusterPolicyReport type for use with
+// ClusterPolicyReport constructs a declarative configuration of the ClusterPolicyReport type for use with
 // apply.
 func ClusterPolicyReport(name string) *ClusterPolicyReportApplyConfiguration {
 	b := &ClusterPolicyReportApplyConfiguration{}
@@ -223,4 +223,10 @@ func (b *ClusterPolicyReportApplyConfiguration) WithResults(values ...*PolicyRep
 		b.Results = append(b.Results, *values[i])
 	}
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *ClusterPolicyReportApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreport.go
+++ b/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreport.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-// PolicyReportApplyConfiguration represents an declarative configuration of the PolicyReport type for use
+// PolicyReportApplyConfiguration represents a declarative configuration of the PolicyReport type for use
 // with apply.
 type PolicyReportApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
@@ -20,7 +20,7 @@ type PolicyReportApplyConfiguration struct {
 	Results                          []PolicyReportResultApplyConfiguration `json:"results,omitempty"`
 }
 
-// PolicyReport constructs an declarative configuration of the PolicyReport type for use with
+// PolicyReport constructs a declarative configuration of the PolicyReport type for use with
 // apply.
 func PolicyReport(name, namespace string) *PolicyReportApplyConfiguration {
 	b := &PolicyReportApplyConfiguration{}
@@ -224,4 +224,10 @@ func (b *PolicyReportApplyConfiguration) WithResults(values ...*PolicyReportResu
 		b.Results = append(b.Results, *values[i])
 	}
 	return b
+}
+
+// GetName retrieves the value of the Name field in the declarative configuration.
+func (b *PolicyReportApplyConfiguration) GetName() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.Name
 }

--- a/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreportresult.go
+++ b/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreportresult.go
@@ -9,7 +9,7 @@ import (
 	v1alpha2 "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
-// PolicyReportResultApplyConfiguration represents an declarative configuration of the PolicyReportResult type for use
+// PolicyReportResultApplyConfiguration represents a declarative configuration of the PolicyReportResult type for use
 // with apply.
 type PolicyReportResultApplyConfiguration struct {
 	Source          *string                                 `json:"source,omitempty"`
@@ -26,7 +26,7 @@ type PolicyReportResultApplyConfiguration struct {
 	Properties      map[string]string                       `json:"properties,omitempty"`
 }
 
-// PolicyReportResultApplyConfiguration constructs an declarative configuration of the PolicyReportResult type for use with
+// PolicyReportResultApplyConfiguration constructs a declarative configuration of the PolicyReportResult type for use with
 // apply.
 func PolicyReportResult() *PolicyReportResultApplyConfiguration {
 	return &PolicyReportResultApplyConfiguration{}

--- a/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreportsummary.go
+++ b/internal/wg-policy/applyconfiguration/wgpolicyk8s.io/v1alpha2/policyreportsummary.go
@@ -2,7 +2,7 @@
 
 package v1alpha2
 
-// PolicyReportSummaryApplyConfiguration represents an declarative configuration of the PolicyReportSummary type for use
+// PolicyReportSummaryApplyConfiguration represents a declarative configuration of the PolicyReportSummary type for use
 // with apply.
 type PolicyReportSummaryApplyConfiguration struct {
 	Pass  *int `json:"pass,omitempty"`
@@ -12,7 +12,7 @@ type PolicyReportSummaryApplyConfiguration struct {
 	Skip  *int `json:"skip,omitempty"`
 }
 
-// PolicyReportSummaryApplyConfiguration constructs an declarative configuration of the PolicyReportSummary type for use with
+// PolicyReportSummaryApplyConfiguration constructs a declarative configuration of the PolicyReportSummary type for use with
 // apply.
 func PolicyReportSummary() *PolicyReportSummaryApplyConfiguration {
 	return &PolicyReportSummaryApplyConfiguration{}


### PR DESCRIPTION
Seems like we need to bundle several upgrades this time.

Awaiting a final release of controller-runtime 0.19.x.