### PR TITLE
chore: bump k8s/k3s to 1.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= "registry.dummy-domain.com/image-scanner/controller:dev"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 1.31.0
 # Namespace to install operator into
 K8S_NAMESPACE ?= image-scanner
 

--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -4,4 +4,4 @@ kind: Simple
 metadata:
   name: image-scanner
 # renovate-image:
-image: docker.io/rancher/k3s:v1.30.2-k3s2
+image: docker.io/rancher/k3s:v1.31.0-k3s1


### PR DESCRIPTION
No idea why the renovate-image marker on the k3s image doesn't work. Any idea @mikaelol?