### PR TITLE
fix: better job condition logic (support K8s 1.31)

### DIFF
--- a/internal/controller/stas/indexer.go
+++ b/internal/controller/stas/indexer.go
@@ -71,11 +71,11 @@ func (r *Indexer) SetupWithManager(mgr ctrl.Manager) error {
 		// TODO: non-exact field matches are not supported by the cache
 		// https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/cache/internal/cache_reader.go#L116-L121
 		// So mapping to [Complete, Failed, NotFinished] where the last is a composite condition
-		switch jc := jobCondition(job); jc {
-		case batchv1.JobComplete:
-			return []string{string(jc)}
-		case batchv1.JobFailed:
-			return []string{string(jc)}
+		switch {
+		case isJobComplete(job):
+			return []string{string(batchv1.JobComplete)}
+		case isJobFailed(job):
+			return []string{string(batchv1.JobFailed)}
 		default:
 			return []string{jobNotFinished}
 		}

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -273,15 +273,15 @@ func (r *ScanJobReconciler) reconcileJob(ctx context.Context, job *batchv1.Job) 
 		}
 	}(logs)
 
-	switch jc := jobCondition(job); jc {
-	case batchv1.JobComplete:
-		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", jc)
+	switch {
+	case isJobComplete(job):
+		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", batchv1.JobComplete)
 		return r.reconcileCompleteJob(ctx, job, logs, cis)
-	case batchv1.JobFailed:
-		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", jc)
+	case isJobFailed(job):
+		logf.FromContext(ctx).V(1).Info("Patching CIS status", "jobCondition", batchv1.JobFailed)
 		return r.reconcileFailedJob(ctx, job, logs, cis)
 	default:
-		return fmt.Errorf("I don't know how to handle job status %q", jc)
+		return fmt.Errorf("I don't know how to handle job status %q", job.Status.String())
 	}
 }
 


### PR DESCRIPTION
Kubernetes 1.31 seems to introduce a new Job status (condition). This breaks the current (dumb) logic. This PR tries to fix this logic, making us support Kubernetes 1.31.