### PR TITLE
ci(e2e-test): try unofficial Trivy DB to mend failing CI

### DIFF
--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -14,6 +14,11 @@ configMapGenerator:
     behavior: merge
     literals:
       - DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db
+  - name: trivy-job-config
+    namespace: image-scanner
+    behavior: merge
+    literals:
+      - JAVA_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-java-db
 patches:
   - patch: |-
       - op: add

--- a/config/e2e-test/kustomization.yaml
+++ b/config/e2e-test/kustomization.yaml
@@ -10,6 +10,10 @@ configMapGenerator:
     literals:
       # Only include chainsaw namespace pattern to reduce resource waste running e2e tests
       - SCAN_NAMESPACE_INCLUDE_REGEXP=^chainsaw-.*
+  - name: trivy-server-config
+    behavior: merge
+    literals:
+      - DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db
 patches:
   - patch: |-
       - op: add


### PR DESCRIPTION
Most Renovate PRs are now failing, and I suspect it's because our e2e-tests are being rate-limited by GHCR. I am hoping that switching to the unofficial DB mirror can help.

https://github.com/statnett/image-scanner-operator/pulls