### PR TITLE
chore(renovate): add marker versioning for k3s image

### DIFF
--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -3,5 +3,5 @@ apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: image-scanner
-# renovate-image:
+# renovate-image: versioning=regex:v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<compatibility>k3s)(?<build>\d+)(\s|$)
 image: docker.io/rancher/k3s:v1.31.0-k3s1


### PR DESCRIPTION
Reverts the change added in https://github.com/statnett/image-scanner-operator/pull/1031.

Currently this marker is not picked up by Renovate, so we don't get automatic updates. At the time before https://github.com/statnett/image-scanner-operator/pull/1031 we had automatic updates by Renovate, so this is an attempt to see if that was a regression.