### PR TITLE
revert: "chore(renovate): add marker versioning for k3s image"

### DIFF
--- a/test/e2e-config/k3d-config.yml
+++ b/test/e2e-config/k3d-config.yml
@@ -3,5 +3,5 @@ apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: image-scanner
-# renovate-image: versioning=regex:v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<compatibility>k3s)(?<build>\d+)(\s|$)
+# renovate-image:
 image: docker.io/rancher/k3s:v1.31.0-k3s1


### PR DESCRIPTION
Reverts statnett/image-scanner-operator#1168

This didn't have the intended effect, and the problem is upstream: https://github.com/statnett/renovate-config/pull/26

(this PR is created with a local branch, to use the revert functionality in the previous PR I had to do this. If this is not desired I can recreate with fork-branch)