### PR TITLE
test(deps): bump envtest to 1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= "registry.dummy-domain.com/image-scanner/controller:dev"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.32.0
 # Namespace to install operator into
 K8S_NAMESPACE ?= image-scanner
 


### PR DESCRIPTION
It seems like the api-server has stronger validations in K8s 1.32.