### PR TITLE
chore: use non-deprecated distroless image ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02
 WORKDIR /
 COPY --from=builder /workspace/manager /image-scanner-operator
 USER 65532:65532


### PR DESCRIPTION
I don't think this is a real issue, but I noticed Renovate displaying an error message on the Dependency Dashboard issue, so I checked the [upstream repo](https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#how-do-i-use-distroless-images). It seems like we are using a deprecated distroless image name. This PR uses the non-deprecated name.