### PR TITLE
feat: make scan job lifetime configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ScanInterval                   time.Duration  `mapstructure:"scan-interval"`
 	ScanJobNamespace               string         `mapstructure:"scan-job-namespace"`
 	ScanJobServiceAccount          string         `mapstructure:"scan-job-service-account"`
-	ScanJobTTLSecondsAfterFinished int32            `mapstructure:"scan-job-ttl-seconds-after-finished"`
+	ScanJobTTLSecondsAfterFinished int32          `mapstructure:"scan-job-ttl-seconds-after-finished"`
 	ScanNamespaces                 []string       `mapstructure:"namespaces"`
 	ScanNamespaceExcludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
 	ScanNamespaceIncludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ScanInterval                   time.Duration  `mapstructure:"scan-interval"`
 	ScanJobNamespace               string         `mapstructure:"scan-job-namespace"`
 	ScanJobServiceAccount          string         `mapstructure:"scan-job-service-account"`
-	ScanJobTTLSecondsAfterFinished int            `mapstructure:"scan-job-ttl-seconds-after-finished"`
+	ScanJobTTLSecondsAfterFinished int32            `mapstructure:"scan-job-ttl-seconds-after-finished"`
 	ScanNamespaces                 []string       `mapstructure:"namespaces"`
 	ScanNamespaceExcludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
 	ScanNamespaceIncludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,17 +8,18 @@ import (
 )
 
 type Config struct {
-	MetricsLabels              []string       `mapstructure:"cis-metrics-labels"`
-	ScanInterval               time.Duration  `mapstructure:"scan-interval"`
-	ScanJobNamespace           string         `mapstructure:"scan-job-namespace"`
-	ScanJobServiceAccount      string         `mapstructure:"scan-job-service-account"`
-	ScanNamespaces             []string       `mapstructure:"namespaces"`
-	ScanNamespaceExcludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
-	ScanNamespaceIncludeRegexp *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
-	ScanWorkloadResources      []string       `mapstructure:"scan-workload-resources"`
-	TrivyImage                 string         `mapstructure:"trivy-image"`
-	TrivyCommand               TrivyCommand   `mapstructure:"trivy-command"`
-	ActiveScanJobLimit         int            `mapstructure:"active-scan-job-limit"`
+	MetricsLabels                  []string       `mapstructure:"cis-metrics-labels"`
+	ScanInterval                   time.Duration  `mapstructure:"scan-interval"`
+	ScanJobNamespace               string         `mapstructure:"scan-job-namespace"`
+	ScanJobServiceAccount          string         `mapstructure:"scan-job-service-account"`
+	ScanJobTTLSecondsAfterFinished int            `mapstructure:"scan-job-ttl-seconds-after-finished"`
+	ScanNamespaces                 []string       `mapstructure:"namespaces"`
+	ScanNamespaceExcludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-exclude-regexp"`
+	ScanNamespaceIncludeRegexp     *regexp.Regexp `mapstructure:"scan-namespace-include-regexp"`
+	ScanWorkloadResources          []string       `mapstructure:"scan-workload-resources"`
+	TrivyImage                     string         `mapstructure:"trivy-image"`
+	TrivyCommand                   TrivyCommand   `mapstructure:"trivy-command"`
+	ActiveScanJobLimit             int            `mapstructure:"active-scan-job-limit"`
 }
 
 type TrivyCommand string

--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -112,11 +112,12 @@ var _ = BeforeSuite(func() {
 	k8sScheme = k8sManager.GetScheme()
 
 	config := config.Config{
-		ScanJobNamespace:      scanJobNamespace,
-		ScanJobServiceAccount: "image-scanner-job",
-		ScanInterval:          time.Hour,
-		TrivyCommand:          config.RootfsTrivyCommand,
-		TrivyImage:            "aquasecurity/trivy",
+		ScanJobNamespace:               scanJobNamespace,
+		ScanJobServiceAccount:          "image-scanner-job",
+		ScanJobTTLSecondsAfterFinished: 60,
+		ScanInterval:                   time.Hour,
+		TrivyCommand:                   config.RootfsTrivyCommand,
+		TrivyImage:                     "aquasecurity/trivy",
 	}
 
 	podReconciler := &PodReconciler{

--- a/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
+++ b/internal/controller/stas/testdata/scan-job/expected-scan-job.yaml
@@ -130,4 +130,4 @@ spec:
           name: image-scanner
         - emptyDir: {}
           name: tmp
-  ttlSecondsAfterFinished: 7200  # Two hours
+  ttlSecondsAfterFinished: 60

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -58,7 +58,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
 	fs.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
 	fs.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
-	fs.Int("scan-job-ttl-seconds-after-finished", 7200, "The lifetime (in seconds) of a scan job that has finished. Value must be > 0 to allow scan reports to be harvested by the operator.")
+	fs.Int("scan-job-ttl-seconds-after-finished", 7200, "The lifetime (in seconds) of a scan job that has finished. Value must be positive to allow scan reports to be harvested by the operator.")
 	fs.String("scan-workload-resources", "", "A comma-separated list of workload resources to scan. Format used for resource is \"resource.group\", i.e. \"deployments.apps\".")
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -58,6 +58,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.Duration("scan-interval", 12*time.Hour, "The minimum time between fetch scan reports from image scanner")
 	fs.String("scan-job-namespace", "", "The namespace to schedule scan jobs.")
 	fs.String("scan-job-service-account", "default", "The service account used to run scan jobs.")
+	fs.Int("scan-job-ttl-seconds-after-finished", 7200, "The lifetime (in seconds) of a scan job that has finished. Value must be > 0 to allow scan reports to be harvested by the operator.")
 	fs.String("scan-workload-resources", "", "A comma-separated list of workload resources to scan. Format used for resource is \"resource.group\", i.e. \"deployments.apps\".")
 	fs.String("scan-namespace-exclude-regexp", "^(kube-|openshift-).*", "regexp for namespace to exclude from scanning")
 	fs.String("scan-namespace-include-regexp", "", "regexp for namespace to include for scanning")
@@ -102,6 +103,10 @@ func (o Operator) UnmarshalConfig(cfg *config.Config) error {
 func (o Operator) ValidateConfig(cfg config.Config) error {
 	if cfg.ScanJobNamespace == "" {
 		return fmt.Errorf("required flag (%q) or env (%q) not set", "scan-job-namespace", "SCAN_JOB_NAMESPACE")
+	}
+
+	if cfg.ScanJobTTLSecondsAfterFinished <= 0 {
+		return fmt.Errorf("flag (%q) or env (%q) must be greater than zero", "scan-job-ttl-seconds-after-finished", "SCAN_JOB_TTL_SECONDS_AFTER_FINISHED")
 	}
 
 	return nil

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -145,7 +145,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	job.Spec.Completions = ptr.To(int32(1))
 	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(3600))
 	job.Spec.BackoffLimit = ptr.To(int32(3))
-	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(f.ScanJobTTLSecondsAfterFinished))
+	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(f.ScanJobTTLSecondsAfterFinished)) // #nosec G115 -- Go is broken in this area
 	job.Spec.Template.Spec.ServiceAccountName = f.ScanJobServiceAccount
 
 	if len(f.preferredNodeNames) > 0 {

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -145,7 +145,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	job.Spec.Completions = ptr.To(int32(1))
 	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(3600))
 	job.Spec.BackoffLimit = ptr.To(int32(3))
-	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(f.ScanJobTTLSecondsAfterFinished)) // #nosec G115 -- Go is broken in this area
+	job.Spec.TTLSecondsAfterFinished = ptr.To(f.ScanJobTTLSecondsAfterFinished)
 	job.Spec.Template.Spec.ServiceAccountName = f.ScanJobServiceAccount
 
 	if len(f.preferredNodeNames) > 0 {

--- a/internal/trivy/scan_job.go
+++ b/internal/trivy/scan_job.go
@@ -145,7 +145,7 @@ func (f *filesystemScanJobBuilder) newImageScanJob(spec stasv1alpha1.ContainerIm
 	job.Spec.Completions = ptr.To(int32(1))
 	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(3600))
 	job.Spec.BackoffLimit = ptr.To(int32(3))
-	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(7200))
+	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(f.ScanJobTTLSecondsAfterFinished))
 	job.Spec.Template.Spec.ServiceAccountName = f.ScanJobServiceAccount
 
 	if len(f.preferredNodeNames) > 0 {


### PR DESCRIPTION
We want to keep scan jobs around shorter than the current default of two hours. This PR surfaces the Kubernetes Job `TTLSecondsAfterFinished` field.