### PR TITLE
ci(renovate): configure rebaseWhen to behind-base-branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,4 +13,5 @@
       "semanticCommitType": "fix",
     },
   ],
+  "rebaseWhen": "behind-base-branch",
 }


### PR DESCRIPTION
To provide a better Renovate experience in this repository, where we require fast-forward merges into main only, I suggest telling R about this. The default is auto, but it doesn't seem to work.

Docs: https://docs.renovatebot.com/configuration-options/#rebasewhen
