### PR TITLE
fix: improve use of kstatus to reconcile pods

### DIFF
--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -8,11 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -51,24 +47,6 @@ func podContainerStatusImagesChanged() predicate.Predicate {
 			return false
 		},
 	}
-}
-
-func isKStatusCurrent() predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(object client.Object) bool {
-		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
-		if err != nil {
-			ctrl.Log.Error(err, "Failed to convert object to unstructured")
-			return false
-		}
-
-		res, err := kstatus.Compute(&unstructured.Unstructured{Object: m})
-		if err != nil {
-			ctrl.Log.Error(err, "Failed to compute KStatus")
-			return false
-		}
-
-		return res.Status == kstatus.CurrentStatus
-	})
 }
 
 func ignoreCreationPredicate() predicate.Predicate {

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -78,7 +78,6 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				podContainerStatusImagesChanged(),
 				predicate.Or(controllerInKinds(groupKinds...), noController),
 				ignoreDeletionPredicate(),
-				isKStatusCurrent(),
 			)).
 		WithEventFilter(predicate.And(predicates...)).
 		Watches(&stasv1alpha1.ContainerImageScan{},


### PR DESCRIPTION
After https://github.com/statnett/image-scanner-operator/pull/1289 we observe a huge reduction in CIS resources in our clusters. I suspect we filter out pods based on stale state. This replaces the predicate with more delicate handling at the start of the reconciling loop.

Reverts https://github.com/statnett/image-scanner-operator/pull/1289

Statuses: https://github.com/kubernetes-sigs/cli-utils/blob/1a9b04556153279603429504ed7ef75c82be6da6/pkg/kstatus/status/status.go#L22-L28