### PR TITLE
ci: replacement for hacked tj-actions/verify-changed-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
           files: .
   verify-generated:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Required to push a commit
-      pull-requests: write # Required to create a pull request
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Generate all
         run: |
           make generate-all
-      # This is a (temporary?) replacement for tj-actions/verify-changed-files which was hacked
+      # A temporary replacement for tj-actions/verify-changed-files which was hacked.
       # https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
-      # If the generated files are updated, this action pushes a commit.
+      # If the generated files are updated, this action fails.
       - uses: int128/update-generated-files-action@65b9a7ae3ededc5679d78343f58fbebcf1ebd785 # v2.57.0
   test:
     needs: verify-generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           make generate-all
       # A temporary replacement for tj-actions/verify-changed-files which was hacked.
       # https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
-      # If the generated files are updated, this action fails.
+      # If the generated files are not up-to-date, this action fails.
       - uses: int128/update-generated-files-action@65b9a7ae3ededc5679d78343f58fbebcf1ebd785 # v2.57.0
   test:
     needs: verify-generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           files: .
   verify-generated:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push a commit
+      pull-requests: write # Required to create a pull request
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
@@ -49,21 +52,10 @@ jobs:
       - name: Generate all
         run: |
           make generate-all
-      - name: Verify changed files
-        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687 # v20.0.1
-        id: verify-changed-files
-        with:
-          files: |
-            **/*
-      - name: Fail job is any changed files
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
-        run: |
-          errorMsg="::error::\
-            Changed files: $CHANGED_FILES\
-            \nPlease run 'make generate-all' locally and commit the changes"
-          echo -e "$errorMsg" && exit 1
+      # This is a (temporary?) replacement for tj-actions/verify-changed-files which was hacked
+      # https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
+      # If the generated files are updated, this action pushes a commit.
+      - uses: int128/update-generated-files-action@65b9a7ae3ededc5679d78343f58fbebcf1ebd785 # v2.57.0
   test:
     needs: verify-generated
     runs-on: ubuntu-latest

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.0.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: containerimagescans.stas.statnett.no
 spec:
   group: stas.statnett.no

--- a/config/crd/bases/stas.statnett.no_containerimagescans.yaml
+++ b/config/crd/bases/stas.statnett.no_containerimagescans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.0.0
   name: containerimagescans.stas.statnett.no
 spec:
   group: stas.statnett.no


### PR DESCRIPTION
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

And all our CI is currently borked because GH deleted the tj-actions organization.

I did a quick search for simple replacements, and while it doesn't do the same, I think https://github.com/int128/update-generated-files-action should achieve the goal of ensuring that generated files are up-to-date.