### PR TITLE
fix: don't requeue any pod events

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -122,13 +122,10 @@ func (r *PodReconciler) reconcilePod() reconcile.Func {
 			}
 
 			switch res.Status {
-			case kstatus.TerminatingStatus:
-				return ctrl.Result{}, nil
 			case kstatus.CurrentStatus:
 				// This is the case we want to reconcile
 			default:
-				logf.FromContext(ctx).Info("requeueing pod in transition", "status", res.Status)
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, nil
 			}
 
 			return ctrl.Result{}, r.reconcile(ctx, pod)


### PR DESCRIPTION
To avoid the event queue being filled with restarting (unhealthy) pods. We are struggling to operate in one of our clusters with a lot of "garbage" workloads.