### PR TITLE
ci(release): improve release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,16 @@
 {
-  "release-type": "go",
+  "always-update": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "extra-files": [
     "kustomization.yaml",
     "README.md"
   ],
   "packages": {
     ".": {}
-  }
+  },
+  "plugins": [
+    "sentence-case"
+  ],
+  "release-type": "go",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
After working with release-please configuration in another project, I have learned something new.

This PR adjusts the release-please configuration to improve the following:

- `always-update: true` to make release-please always update the release PR. We only allow fast-forward merges in this project, so without this a user must rebase anyway.
- add `sentence-case` plugin - which will allow us to be more lenient with PR titles.
- add JSON schema reference to better support IDEs.
- `bump-patch-for-minor-pre-major: false` (the default) to make new feature more "visible" in releases.

Some references:

- https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
- https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#sentence-case