### PR TITLE
feat: wait for vacant slot when max scan jobs running

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	TrivyImage                     string         `mapstructure:"trivy-image"`
 	TrivyCommand                   TrivyCommand   `mapstructure:"trivy-command"`
 	ActiveScanJobLimit             int            `mapstructure:"active-scan-job-limit"`
+	ActiveScanJobMaxWaitDuration   time.Duration  `mapstructure:"active-scan-job-limit-max-wait-duration"`
 }
 
 type TrivyCommand string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	TrivyImage                     string         `mapstructure:"trivy-image"`
 	TrivyCommand                   TrivyCommand   `mapstructure:"trivy-command"`
 	ActiveScanJobLimit             int            `mapstructure:"active-scan-job-limit"`
-	ActiveScanJobMaxWaitDuration   time.Duration  `mapstructure:"active-scan-job-limit-max-wait-duration"`
+	ActiveScanJobMaxWaitDuration   time.Duration  `mapstructure:"active-scan-job-max-wait-duration"`
 }
 
 type TrivyCommand string

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -2,7 +2,6 @@ package stas
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -60,12 +59,25 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		if r.ActiveScanJobLimit > 0 {
-			count, err := r.activeJobCount(ctx)
+			count, err := r.activeScanJobCount(ctx)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+
+			if r.ActiveScanJobMaxWaitDuration > 0 {
+				// Max number of active scan jobs reached. Waiting for a vacant scan job slot
+				// for up to ActiveScanJobMaxWaitDuration before giving up.
+				startTime := time.Now()
+				for count >= r.ActiveScanJobLimit && time.Since(startTime) < r.ActiveScanJobMaxWaitDuration {
+					count, err = r.activeScanJobCount(ctx)
+					if err != nil {
+						return ctrl.Result{}, err
+					}
+				}
+			}
+
 			if count >= r.ActiveScanJobLimit {
-				// Max number of active scan jobs reached. Requeue request
+				// Max number of active scan jobs reached. Requeue request.
 				return ctrl.Result{Requeue: true}, nil
 			}
 		}
@@ -74,39 +86,6 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	return controller.Reconcile(ctx, fn)
-}
-
-func (r *ContainerImageScanReconciler) activeJobCount(ctx context.Context) (int, error) {
-	count, err := r.activeScanJobCount(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	if count >= r.ActiveScanJobLimit && r.ActiveScanJobMaxWaitDuration > 0 {
-		// Max number of active scan jobs reached. Waiting for a vacant scan job slot
-		// for up to ActiveScanJobMaxWaitDuration before giving up.
-		ctx, cancel := context.WithTimeout(ctx, r.ActiveScanJobMaxWaitDuration)
-		defer cancel()
-
-		for count >= r.ActiveScanJobLimit {
-			select {
-			case <-ctx.Done():
-				return count, nil
-			default:
-				newCount, err := r.activeScanJobCount(ctx)
-				if err != nil {
-					if errors.Is(err, context.Canceled) {
-						return count, nil
-					}
-					return 0, err
-				}
-
-				count = newCount
-			}
-		}
-	}
-
-	return count, nil
 }
 
 func (r *ContainerImageScanReconciler) activeScanJobCount(ctx context.Context) (int, error) {

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -65,6 +65,7 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return ctrl.Result{}, err
 			}
 			if count >= r.ActiveScanJobLimit {
+				// Max number of active scan jobs reached. Requeue request
 				return ctrl.Result{Requeue: true}, nil
 			}
 		}

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -69,6 +69,8 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 				// for up to ActiveScanJobMaxWaitDuration before giving up.
 				startTime := time.Now()
 				for count >= r.ActiveScanJobLimit && time.Since(startTime) < r.ActiveScanJobMaxWaitDuration {
+					time.Sleep(10 * time.Millisecond)
+
 					count, err = r.activeScanJobCount(ctx)
 					if err != nil {
 						return ctrl.Result{}, err

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -67,7 +67,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
-	fs.Duration("active-scan-job-limit-max-wait-duration", 3*time.Second, "When active scan job limit reached, the maximum max duration to wait for a vacant slot before requeuing.")
+	fs.Duration("active-scan-job-limit-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -67,6 +67,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
+	fs.Duration("active-scan-job-limit-max-wait-duration", 3*time.Second, "When active scan job limit reached, the maximum max duration to wait for a vacant slot before requeuing.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}


### PR DESCRIPTION
`workqueue_depth` is currently 0, while `workqueue_retries` is very high (at times > 1000/second). Adding a wait-for-vacant-job-slot feature to not run through and requeue the entire queue, but instead wait a bit when a scan job cannot be scheduled.

Hopfully now showing a real `workqueue_depth` value.