### PR TITLE
revert: requeue after 1s when pod not ready, to avoid many reconciles ...

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -130,7 +129,7 @@ func (r *PodReconciler) reconcilePod() reconcile.Func {
 				// This is the case we want to reconcile
 			default:
 				logf.FromContext(ctx).Info("requeueing pod in transition", "status", res.Status)
-				return ctrl.Result{RequeueAfter: time.Second}, nil
+				return ctrl.Result{Requeue: true}, nil
 			}
 
 			return ctrl.Result{}, r.reconcile(ctx, pod)


### PR DESCRIPTION
Reverts statnett/image-scanner-operator#1383 as it resulted in 1s reconcile loop without incremental backoff. Should use https://github.com/statnett/image-scanner-operator/pull/1388 to tweak valid statuses instead.