### PR TITLE
fix: active-scan-job-max-wait-duration flag

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -68,7 +68,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
-	fs.Duration("active-scan-job-limit-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
+	fs.Duration("active-scan-job-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}


### PR DESCRIPTION
typo in https://github.com/statnett/image-scanner-operator/pull/1382

ref https://github.com/statnett/image-scanner-operator/blob/f84fa69885cce2061410c82c5294605f0fd8d019/internal/config/config.go#L24