### PR TITLE
refactor: remove redundant namespace list option

### DIFF
--- a/internal/controller/stas/rescan.go
+++ b/internal/controller/stas/rescan.go
@@ -31,7 +31,7 @@ func (r *RescanTrigger) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			cisList := &stasv1alpha1.ContainerImageScanList{}
-			if err := r.List(ctx, cisList, client.InNamespace("")); err != nil {
+			if err := r.List(ctx, cisList); err != nil {
 				log.Error(err, "failed to list CISes")
 				continue
 			}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -126,7 +126,7 @@ func (c ImageMetricsCollector) Collect(metrics chan<- prometheus.Metric) {
 	ctx := context.Background()
 
 	cisList := &stasv1alpha1.ContainerImageScanList{}
-	if err := c.List(ctx, cisList, client.InNamespace("")); err != nil {
+	if err := c.List(ctx, cisList); err != nil {
 		// TODO: Log
 		return
 	}


### PR DESCRIPTION
Or is there some reason for including it?