### PR TITLE
fix: dont reconcile when scan not needed

### DIFF
--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -120,6 +120,7 @@ func (r *ContainerImageScanReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			builder.WithPredicates(
 				predicate.GenerationChangedPredicate{},
 				ignoreDeletionPredicate(),
+				predicate.Not(cisScannedInInterval(r.ScanInterval)),
 			)).
 		WithEventFilter(predicate.And(predicates...)).
 		WatchesRawSource(source.Channel(r.EventChan, &handler.EnqueueRequestForObject{})).

--- a/internal/controller/stas/predicates.go
+++ b/internal/controller/stas/predicates.go
@@ -3,6 +3,7 @@ package stas
 import (
 	"regexp"
 	"slices"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -70,6 +71,13 @@ func podHasWaitingReason(reason ...string) predicate.Predicate {
 		}
 
 		return false
+	})
+}
+
+func cisScannedInInterval(interval time.Duration) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		cis := object.(*stasv1alpha1.ContainerImageScan)
+		return cis.Status.LastScanTime != nil && time.Since(cis.Status.LastScanTime.Time) < interval
 	})
 }
 


### PR DESCRIPTION
Avoid enqueuing cis that does not need new scan

Could also be done as an early exit in the reconcile, but I think this will work as we have the scheduling ticker.