### PR TITLE
chore!: remove wait feature

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,6 @@ type Config struct {
 	TrivyImage                     string         `mapstructure:"trivy-image"`
 	TrivyCommand                   TrivyCommand   `mapstructure:"trivy-command"`
 	ActiveScanJobLimit             int            `mapstructure:"active-scan-job-limit"`
-	ActiveScanJobMaxWaitDuration   time.Duration  `mapstructure:"active-scan-job-max-wait-duration"`
 }
 
 type TrivyCommand string

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -58,30 +58,14 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, nil
 		}
 
-		if r.ActiveScanJobLimit > 0 {
-			count, err := r.activeScanJobCount(ctx)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
+		count, err := r.activeScanJobCount(ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-			if r.ActiveScanJobMaxWaitDuration > 0 {
-				// Max number of active scan jobs reached. Waiting for a vacant scan job slot
-				// for up to ActiveScanJobMaxWaitDuration before giving up.
-				startTime := time.Now()
-				for count >= r.ActiveScanJobLimit && time.Since(startTime) < r.ActiveScanJobMaxWaitDuration {
-					time.Sleep(10 * time.Millisecond)
-
-					count, err = r.activeScanJobCount(ctx)
-					if err != nil {
-						return ctrl.Result{}, err
-					}
-				}
-			}
-
-			if count >= r.ActiveScanJobLimit {
-				// Max number of active scan jobs reached. Requeue request.
-				return ctrl.Result{Requeue: true}, nil
-			}
+		if r.ActiveScanJobLimit > 0 && count >= r.ActiveScanJobLimit {
+			// Max number of active scan jobs reached. Requeue request
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return r.reconcile(ctx, cis)

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -58,14 +58,16 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, nil
 		}
 
-		count, err := r.activeScanJobCount(ctx)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		if r.ActiveScanJobLimit > 0 {
+			count, err := r.activeScanJobCount(ctx)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 
-		if r.ActiveScanJobLimit > 0 && count >= r.ActiveScanJobLimit {
-			// Max number of active scan jobs reached. Requeue request
-			return ctrl.Result{Requeue: true}, nil
+			if count >= r.ActiveScanJobLimit {
+				// Max number of active scan jobs reached. Requeue request.
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 
 		return r.reconcile(ctx, cis)

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -68,7 +68,7 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
-	fs.Duration("active-scan-job-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
+	fs.Duration("active-scan-job-limit-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -68,7 +68,6 @@ func (o Operator) BindFlags(cfg *config.Config, fs *flag.FlagSet) error {
 	fs.String("trivy-command", string(config.RootfsTrivyCommand), "The trivy command used to scan filesystem in image; can be 'filesystem' or 'rootfs'")
 	fs.String("trivy-image", "", "The image used for obtaining the trivy binary.")
 	fs.Int("active-scan-job-limit", 8, "The maximum number of active scan jobs. Setting it to 0 will disable the limit.")
-	fs.Duration("active-scan-job-limit-max-wait-duration", 0, "When active scan job limit reached, the maximum duration to wait for a vacant slot before requeuing.")
 	fs.Bool("help", false, "print out usage and a summary of options")
 
 	pfs := &pflag.FlagSet{}


### PR DESCRIPTION
Fixed the problem with workqueue always being zero, but do not want this time-based block here.

Could in the future wait on a golang channel from the controller working with jobs, and block untill a slot is known to be available.