### PR TITLE
fix: remove scanned within interval check

### DIFF
--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -3,7 +3,6 @@ package stas
 import (
 	"context"
 	"fmt"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,12 +49,6 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 		cis := &stasv1alpha1.ContainerImageScan{}
 		if err := r.Get(ctx, req.NamespacedName, cis); err != nil {
 			return ctrl.Result{}, staserrors.Ignore(err, apierrors.IsNotFound)
-		}
-
-		lastSuccessfulScanTime := cis.Status.LastSuccessfulScanTime
-		if !lastSuccessfulScanTime.IsZero() && time.Since(lastSuccessfulScanTime.Time) < r.ScanInterval {
-			// Successful scan within scan interval; nothing to do
-			return ctrl.Result{}, nil
 		}
 
 		if r.ActiveScanJobLimit > 0 {


### PR DESCRIPTION
Made a predicate in https://github.com/statnett/image-scanner-operator/pull/1394, and the ticker performs it's own check https://github.com/statnett/image-scanner-operator/blob/aadaee5bae0f06d074503ad505fe49993ac8c528/internal/controller/stas/containerimagescan_controller.go#L56

Should therefore never occur here