### PR TITLE
feat: best-effort copy of existing scan results if job limit is hit

### DIFF
--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -54,8 +54,10 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		var latest *stasv1alpha1.ContainerImageScan
+
 		if r.ReuseScanResults {
 			var err error
+
 			latest, err = r.latestDigestScan(ctx, cis.Spec.Digest)
 			if err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
Not totally sure this is a good approach.

To provide some info about a CIS instead of it remaining status-less for a long time when many are scheduled at once.

The CIS is still requeued, to trigger a fresh scan as soon as possible.