### PR TITLE
chore: migrate deprecated wsl linter to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,11 +11,15 @@ linters:
     - predeclared
     - unparam
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     gocritic:
       enabled-checks:
         - importShadow
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
 formatters:
   enable:
     - gofmt

--- a/internal/controller/stas/containerimagescan_status.go
+++ b/internal/controller/stas/containerimagescan_status.go
@@ -53,6 +53,7 @@ type containerImageScanStatusPatch struct {
 func (p *containerImageScanStatusPatch) withCondition(c *metav1ac.ConditionApplyConfiguration) *containerImageScanStatusPatch {
 	p.patch.Status.
 		WithConditions(NewConditionsPatch(p.cis.Status.Conditions, c)...)
+
 	return p
 }
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -118,7 +118,9 @@ func (c ImageMetricsCollector) NeedLeaderElection() bool {
 
 func (c ImageMetricsCollector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- c.successDesc
+
 	descs <- c.issuesDesc
+
 	descs <- c.patchStatusDesc
 }
 
@@ -148,6 +150,7 @@ func (c ImageMetricsCollector) Collect(metrics chan<- prometheus.Metric) {
 		if meta.IsStatusConditionTrue(cis.Status.Conditions, string(kstatus.ConditionStalled)) {
 			successValue = float64(0)
 		}
+
 		metrics <- prometheus.MustNewConstMetric(c.successDesc, prometheus.GaugeValue, successValue, cisLabelValues...)
 
 		severities := cis.Status.VulnerabilitySummary.GetSeverityCount()


### PR DESCRIPTION
The wsl linter is marked as deprecated in golangci-lint and replaced with the new wsl_v5 linter.