### PR TITLE
chore: correct bad Renovate upgrade

### DIFF
--- a/internal/controller/stas/suite_test.go
+++ b/internal/controller/stas/suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 	Expect(appsv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(stasv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(batchv1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(openreportsv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(openreportsv1alpha1.Install(scheme.Scheme)).To(Succeed())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -43,7 +43,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(stasv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(openreportsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(openreportsv1alpha1.Install(scheme))
 }
 
 type Operator struct{}


### PR DESCRIPTION
We were missing golangci-lint from the required status checks, which I have now fixed.