### PR TITLE
refactor: migrate to new c/r Apply function

### DIFF
--- a/internal/controller/stas/containerimagescan_status.go
+++ b/internal/controller/stas/containerimagescan_status.go
@@ -93,7 +93,7 @@ func (p *containerImageScanStatusPatch) apply(ctx context.Context, c client.Clie
 	}
 
 	if p.minSeverity == nil {
-		if err := c.Status().Patch(ctx, p.cis, applyPatch{p.patch}, FieldValidationStrict, client.ForceOwnership, fieldOwner); err != nil {
+		if err := c.Status().Patch(ctx, p.cis, applyPatch{p.patch}, client.FieldValidation(metav1.FieldValidationStrict), client.ForceOwnership, fieldOwner); err != nil {
 			return fmt.Errorf("when patching status: %w", err)
 		}
 
@@ -107,7 +107,7 @@ func (p *containerImageScanStatusPatch) apply(ctx context.Context, c client.Clie
 			return *v.Severity < severity
 		})
 
-		err = c.Status().Patch(ctx, p.cis, applyPatch{p.patch}, FieldValidationStrict, client.ForceOwnership, fieldOwner)
+		err = c.Status().Patch(ctx, p.cis, applyPatch{p.patch}, client.FieldValidation(metav1.FieldValidationStrict), client.ForceOwnership, fieldOwner)
 		if !isResourceTooLargeError(err) {
 			break
 		}

--- a/internal/controller/stas/policy_report.go
+++ b/internal/controller/stas/policy_report.go
@@ -54,10 +54,6 @@ func (p *policyReportPatch) apply(ctx context.Context, c client.Client, scheme *
 		return err
 	}
 
-	report := &openreportsv1alpha1.Report{}
-	report.Name = *p.patch.Name
-	report.Namespace = *p.patch.Namespace
-
 	var err error
 	// Repeat until resource fits in api-server by increasing minimum severity on failure.
 	for severity := p.minSeverity; severity <= stasv1alpha1.MaxSeverity; severity++ {
@@ -70,7 +66,7 @@ func (p *policyReportPatch) apply(ctx context.Context, c client.Client, scheme *
 			p.patch.Results[i] = *policyReportResultPatch(v)
 		}
 
-		err = c.Patch(ctx, report, applyPatch{p.patch}, FieldValidationStrict, client.ForceOwnership, fieldOwner)
+		err = c.Apply(ctx, p.patch, client.ForceOwnership, fieldOwner)
 		if !isResourceTooLargeError(err) {
 			break
 		}

--- a/internal/controller/stas/ssa_client.go
+++ b/internal/controller/stas/ssa_client.go
@@ -47,37 +47,6 @@ func (p applyPatch) Data(_ client.Object) ([]byte, error) {
 	return json.Marshal(p.patch)
 }
 
-// FieldValidationStrict instructs the server on how to handle
-// objects in the request (POST/PUT/PATCH) containing unknown
-// or duplicate fields. This will fail the request with a BadRequest
-// error if any unknown fields would be dropped from the object, or if any
-// duplicate fields are present. The error returned from the server
-// will contain all unknown and duplicate fields encountered.
-var FieldValidationStrict = fieldValidationStrict{}
-
-var (
-	_ client.PatchOption            = fieldValidationStrict{}
-	_ client.SubResourcePatchOption = fieldValidationStrict{}
-)
-
-type fieldValidationStrict struct{}
-
-func (fieldValidationStrict) ApplyToPatch(opts *client.PatchOptions) {
-	if opts.Raw == nil {
-		opts.Raw = &metav1.PatchOptions{}
-	}
-
-	opts.Raw.FieldValidation = "Strict"
-}
-
-func (fieldValidationStrict) ApplyToSubResourcePatch(opts *client.SubResourcePatchOptions) {
-	if opts.Raw == nil {
-		opts.Raw = &metav1.PatchOptions{}
-	}
-
-	opts.Raw.FieldValidation = "Strict"
-}
-
 func NewConditionsPatch(existingConditions []metav1.Condition, conditions ...*metav1ac.ConditionApplyConfiguration) []*metav1ac.ConditionApplyConfiguration {
 	for _, condition := range conditions {
 		if condition.LastTransitionTime.IsZero() {

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -233,7 +233,7 @@ func (r *PodReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
 			return err
 		}
 
-		if err := r.Patch(ctx, cisObj, applyPatch{cis}, FieldValidationStrict, client.ForceOwnership, fieldOwner); err != nil {
+		if err := r.Apply(ctx, cis, client.ForceOwnership, fieldOwner); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We have now upgraded controller-runtime to the latest release, which contains a new `client.Apply` function to perform native SSA requests.