### PR TITLE
fix: also create policy report when reusing report from CIS

### DIFF
--- a/internal/controller/stas/policy_report.go
+++ b/internal/controller/stas/policy_report.go
@@ -11,6 +11,7 @@ import (
 	openreportsv1alpha1ac "github.com/openreports/reports-api/pkg/client/applyconfiguration/openreports.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
@@ -38,9 +39,9 @@ type policyReportPatch struct {
 	minSeverity     stasv1alpha1.Severity
 }
 
-func (p *policyReportPatch) withResults(vulnerabilities []stasv1alpha1.Vulnerability, summary *stasv1alpha1.VulnerabilitySummary, minSeverity stasv1alpha1.Severity) *policyReportPatch {
+func (p *policyReportPatch) withResults(vulnerabilities []stasv1alpha1.Vulnerability, summary *stasv1alpha1.VulnerabilitySummary, minSeverity *stasv1alpha1.Severity) *policyReportPatch {
 	p.vulnerabilities = vulnerabilities
-	p.minSeverity = minSeverity
+	p.minSeverity = ptr.Deref(minSeverity, stasv1alpha1.MinSeverity)
 
 	p.patch.
 		WithSummary(openreportsv1alpha1ac.ReportSummary().

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -187,7 +187,7 @@ func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batch
 
 	if config.DefaultFeatureGate.Enabled(feature.PolicyReport) {
 		err = newPolicyReportPatch(cis).
-			withResults(vulnerabilities, summary, minSeverity).
+			withResults(vulnerabilities, summary, &minSeverity).
 			apply(ctx, r.Client, r.Scheme)
 		if err != nil {
 			return err


### PR DESCRIPTION
This appears to be an oversight in https://github.com/statnett/image-scanner-operator/pull/1424. We noticed this when enabling e2e-tests for policy reports in a cluster where all tests run in the same namespace. The cronjob test CIS reuses the scan results of the job test, but no policy report.