### PR TITLE
fix(trivy): halve default server cache TTL

### DIFF
--- a/config/trivy-server/kustomization.yaml
+++ b/config/trivy-server/kustomization.yaml
@@ -16,6 +16,6 @@ configMapGenerator:
     literals:
       - LISTEN=0.0.0.0:4954
       - CACHE_DIR=/home/scanner/.cache/trivy
-      # Approximately 6 months
-      - CACHE_TTL=4320h
+      # Approximately 3 months
+      - CACHE_TTL=2160h
       - DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db


### PR DESCRIPTION
Reduces the default trivy server `CACHE_TTL` from `4320h` (180 days) to `2160h` (90 days).

The longer TTL allows scan-result cache entries to accumulate for up to
6 months, which grows the trivy server's PVC over time. Halving the TTL
bounds this growth while still giving good cache hit rates for repeated
scans of the same image digests.
