### PR TITLE
fix(scan-job): don't delete a scan Job that is still running

### DIFF
--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -177,9 +177,30 @@ func (r *ContainerImageScanReconciler) reconcile(ctx context.Context, cis *stasv
 	err = r.Create(ctx, scanJob)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			// Job already exists; delete it and requeue
+			existing := &batchv1.Job{}
+			if getErr := r.Get(ctx, client.ObjectKeyFromObject(scanJob), existing); getErr != nil {
+				return result, getErr
+			}
+
+			if !isJobComplete(existing) && !isJobFailed(existing) {
+				// Scan job already exists and is still running. Deleting it here would
+				// kill an in-progress scan and immediately recreate it, which can
+				// livelock indefinitely for any scan that takes longer than the
+				// rescan check interval (RescanTrigger keeps requeuing stale CISes
+				// on a fixed tick, without knowing a scan is already in flight).
+				// Let the running job finish; ScanJobReconciler will pick up its
+				// result and update the CIS status once it completes.
+				logf.FromContext(ctx).V(1).Info("Scan job already exists and is still running, not recreating", "job", existing.Name)
+
+				return result, nil
+			}
+
+			// Job already exists but is finished (e.g. not yet cleaned up by TTL);
+			// delete it and requeue so a fresh scan job can be created.
 			err = r.Delete(ctx, scanJob, client.PropagationPolicy(metav1.DeletePropagationBackground))
 			result.Requeue = true //nolint:staticcheck // SA1019: FIXME: https://github.com/kubernetes-sigs/controller-runtime/pull/3107#issuecomment-2648121233
+
+			return result, err
 		}
 
 		return result, err

--- a/internal/controller/stas/containerimagescan_controller_test.go
+++ b/internal/controller/stas/containerimagescan_controller_test.go
@@ -106,6 +106,44 @@ var _ = Describe("ContainerImageScan controller", func() {
 		Expect(scanJob2.UID).To(Not(Equal(scanJob.UID)))
 	})
 
+	It("should not recreate a scan job that is still running", func() {
+		// Regression test: a scan job that takes longer to complete than the
+		// rescan check interval must not be deleted and recreated by a
+		// subsequent reconcile triggered while it is still active. Doing so
+		// livelocks indefinitely, since the replacement job never gets a
+		// chance to finish either.
+		cis := &stasv1alpha1.ContainerImageScan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx-still-running",
+				Namespace: DefaultNamespaceName,
+			},
+			Spec: stasv1alpha1.ContainerImageScanSpec{
+				ImageScanSpec: stasv1alpha1.ImageScanSpec{
+					Image: stasv1alpha1.Image{
+						Name:   "docker.io/nginxinc/nginx-unprivileged",
+						Digest: "sha256:11111111111111111111111111111111111111111111111111111111111111",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cis)).To(Succeed())
+
+		// Wait for scan job to be created; leave it running (no Complete/Failed
+		// condition set), simulating a scan that is still in progress.
+		scanJob := getContainerImageScanJob(cis)
+
+		// Simulate the RescanTrigger firing again while the scan job above is
+		// still active, e.g. because LastScanTime hasn't been updated yet.
+		// The suite's RescanTrigger ticks every second (see suite_test.go), so
+		// this will very quickly cause another reconcile of this CIS.
+		Expect(komega.UpdateStatus(cis, func() {
+			cis.Status.LastScanTime = &metav1.Time{Time: time.Now().Add(-time.Hour * 12)}
+		})()).To(Succeed())
+
+		// The still-running job must not be deleted or replaced.
+		Consistently(komega.Object(scanJob)).Should(HaveField("UID", scanJob.UID))
+	})
+
 	It("should copy an existing recent scan result", func() {
 		latestDigestScanTime := metav1.Time{Time: time.Now().Add(-time.Minute)}
 


### PR DESCRIPTION
```
   ContainerImageScanReconciler.reconcile creates a scan Job named
   deterministically from the CIS (name plus a hash of the spec). When a
   Job with that name already exists, the reconciler unconditionally
   deleted it and requeued, regardless of whether the existing Job had
   actually finished.

   RescanTrigger fires a GenericEvent for any CIS whose LastScanTime is
   older than ScanInterval, on a fixed CheckInterval that is hardcoded to
   one minute and not configurable. LastScanTime is only advanced when a
   scan Job reaches a terminal state (Complete or Failed), or when results
   are copied from another CIS with the same digest. So for any scan that
   takes longer than CheckInterval to finish, every subsequent tick
   re-triggers a reconcile that sees the still-running Job via
   IsAlreadyExists and deletes it before it can reach either terminal
   state. The replacement Job faces the same fate on the next tick, so the
   scan can never succeed: it livelocks, generating a new (identical,
   equally doomed) scan Job every CheckInterval.

   Onset happens on the first tick after LastScanTime goes stale, i.e.
   once per ScanInterval following a successful scan. But once entered,
   the loop is permanent: LastScanTime can never advance, so the CIS never
   recovers without intervention. We had one CIS stuck this way for 8
   days, spanning roughly 16 consecutive ScanInterval windows. Triggering
   this needs no misconfiguration and no pathological image, only a scan
   slower than CheckInterval. In our cluster two large images hit it, one
   measured at 69s against the 60s tick; each generated about 1440 scan
   Jobs per day re-scanning an unchanging image digest, with the
   corresponding pod churn and load on the shared trivy server.

   Fix: before deleting an already-existing Job, fetch it and check
   whether it has actually finished (Complete or Failed). If it is still
   active, leave it alone and let it run to completion - ScanJobReconciler
   will pick up the result once it is done. Only delete and recreate the
   Job if it already exists but has finished (e.g. not yet cleaned up by
   the TTL controller).

   Note: RescanTrigger will still keep firing GenericEvents every
   CheckInterval for a CIS whose scan is taking a while, since it only
   looks at LastScanTime. That is now a harmless no-op (a Get plus early
   return) rather than a destructive delete, but a follow-up could make
   RescanTrigger itself aware of in-flight scans to avoid the redundant
   reconciles entirely.
```