### PR TITLE
fix: replace use of deprecated Result.Requeue with Result.RequeueAfter

### DIFF
--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -3,9 +3,10 @@ package controller
 import (
 	"context"
 
-	staserrors "github.com/statnett/image-scanner-operator/internal/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	staserrors "github.com/statnett/image-scanner-operator/internal/errors"
 )
 
 type ReconcileFn func(context.Context) (ctrl.Result, error)

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -3,30 +3,14 @@ package controller
 import (
 	"context"
 
+	staserrors "github.com/statnett/image-scanner-operator/internal/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	staserrors "github.com/statnett/image-scanner-operator/internal/errors"
 )
 
 type ReconcileFn func(context.Context) (ctrl.Result, error)
 
 func Reconcile(ctx context.Context, reconcileFn ReconcileFn) (ctrl.Result, error) {
 	result, err := reconcileFn(ctx)
-	if apierrors.IsConflict(err) {
-		// Resource conflict; requeue the request
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	if apierrors.IsAlreadyExists(err) {
-		// Log error message as warning (-1 = WARN)
-		logf.FromContext(ctx, "error", err.Error()).
-			V(-1).
-			Info("Assuming transient error (race condition), requeuing request")
-
-		return ctrl.Result{Requeue: true}, nil //nolint:staticcheck // SA1019: FIXME: https://github.com/kubernetes-sigs/controller-runtime/pull/3107#issuecomment-2648121233
-	}
-
 	return result, staserrors.IgnoreAny(err, staserrors.IsNamespaceTerminating, apierrors.IsNotFound)
 }

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -29,8 +29,8 @@ func TestReconcile(t *testing.T) {
 	}{
 		{name: "no error", args: args{reconcileFn: reconcileError(nil)}},
 		{name: "unrelated", args: args{reconcileFn: reconcileError(errors.New("error"))}, wantErr: true},
-		{name: "conflict", args: args{reconcileFn: reconcileError(apierrors.NewConflict(gr, "name", nil))}, want: ctrl.Result{Requeue: true}},
-		{name: "already exists", args: args{reconcileFn: reconcileError(apierrors.NewAlreadyExists(gr, "name"))}, want: ctrl.Result{Requeue: true}},
+		{name: "conflict", args: args{reconcileFn: reconcileError(apierrors.NewConflict(gr, "name", nil))}, wantErr: true},
+		{name: "already exists", args: args{reconcileFn: reconcileError(apierrors.NewAlreadyExists(gr, "name"))}, wantErr: true},
 		{name: "not found", args: args{reconcileFn: reconcileError(apierrors.NewNotFound(gr, "name"))}},
 		{name: "namespace terminating", args: args{reconcileFn: reconcileError(newNamespaceTerminatingError())}},
 	}

--- a/internal/controller/stas/containerimagescan_controller.go
+++ b/internal/controller/stas/containerimagescan_controller.go
@@ -85,8 +85,8 @@ func (r *ContainerImageScanReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 
 			if count >= r.ActiveScanJobLimit {
-				// Max number of active scan jobs reached. Requeue request.
-				return ctrl.Result{Requeue: true}, nil
+				// Max number of active scan jobs reached. Requeue request with some delay.
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
 		}
 
@@ -198,7 +198,7 @@ func (r *ContainerImageScanReconciler) reconcile(ctx context.Context, cis *stasv
 			// Job already exists but is finished (e.g. not yet cleaned up by TTL);
 			// delete it and requeue so a fresh scan job can be created.
 			err = r.Delete(ctx, scanJob, client.PropagationPolicy(metav1.DeletePropagationBackground))
-			result.Requeue = true //nolint:staticcheck // SA1019: FIXME: https://github.com/kubernetes-sigs/controller-runtime/pull/3107#issuecomment-2648121233
+			result.RequeueAfter = 5 * time.Second
 
 			return result, err
 		}

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -123,7 +124,7 @@ func (r *ScanJobReconciler) reconcileBackOffJobPod() reconcile.Func {
 
 				logf.FromContext(ctx).V(1).Info("no waiting state found", "expectedReasons", expectedReasons)
 				// Pod (in controller cache) has not yet reached waiting state. Requeue event
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 
 			podController := metav1.GetControllerOf(p)

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -128,7 +129,7 @@ func (r *PodReconciler) reconcilePod() reconcile.Func {
 				// This is the case we want to reconcile
 			default:
 				logf.FromContext(ctx).Info("requeueing pod in transition", "status", res.Status)
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 
 			return ctrl.Result{}, r.reconcile(ctx, pod)


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

To hopefully make https://github.com/statnett/image-scanner-operator/pull/1833 happy. For some reason, the latest golangci-lint release is detecting use of deprecated code that the current version didn't detect.

Instead of migrating the custom handling of conflicts and "already exists" errors, I propose treating these as any other error, which will end up in the common error handling, triggering a retry with rate limiting (and backoff). Conflicts are rare when using SSA, as we now do.