### PR TITLE
fix: ignore pods in transition even more

### DIFF
--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -122,7 +122,7 @@ func (r *PodReconciler) reconcilePod() reconcile.Func {
 			}
 
 			if res.Status != kstatus.CurrentStatus {
-				logf.FromContext(ctx).V(1).Info("ignoring event for pod in transition", "status", res.Status)
+				logf.FromContext(ctx).V(1).Info("skipping pod, status is not Current", "status", res.Status)
 				return ctrl.Result{}, nil
 			}
 

--- a/internal/controller/stas/workload_controller.go
+++ b/internal/controller/stas/workload_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -122,14 +121,9 @@ func (r *PodReconciler) reconcilePod() reconcile.Func {
 				return ctrl.Result{}, fmt.Errorf("when computing pod kstatus: %w", err)
 			}
 
-			switch res.Status {
-			case kstatus.TerminatingStatus:
+			if res.Status != kstatus.CurrentStatus {
+				logf.FromContext(ctx).V(1).Info("ignoring event for pod in transition", "status", res.Status)
 				return ctrl.Result{}, nil
-			case kstatus.CurrentStatus:
-				// This is the case we want to reconcile
-			default:
-				logf.FromContext(ctx).Info("requeueing pod in transition", "status", res.Status)
-				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 
 			return ctrl.Result{}, r.reconcile(ctx, pod)


### PR DESCRIPTION
<!-- Please set the title of this PR according to https://www.conventionalcommits.org/en/v1.0.0/#summary, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

After https://github.com/statnett/image-scanner-operator/pull/1836, and probably before too, the logs are spammed with highly irrelevant information. Example:

````json
{"level":"info","ts":"2026-08-21T13:37:26.228Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"adls-connector-6976bd54d-rbfv4","namespace":"k8s-connect-adls"},"namespace":"k8s-connect-adls","name":"adls-connector-6976bd54d-rbfv4","reconcileID":"11b9da0c-5e0b-4835-924f-8fd62448ec37","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.351Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"operator-activation-remote-7d4d87c6cf-nrm48","namespace":"acti-bifrost-antony-test-env"},"namespace":"acti-bifrost-antony-test-env","name":"operator-activation-remote-7d4d87c6cf-nrm48","reconcileID":"c30f12b4-a65a-41dd-8608-7328b79e1a8f","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.359Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"landingpage-ui-7b8f5565d5-m227m","namespace":"form-develop"},"namespace":"form-develop","name":"landingpage-ui-7b8f5565d5-m227m","reconcileID":"0b8c592f-2416-410d-a1ef-444c29261a24","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.423Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"schema-registry-846b7c5f79-x789m","namespace":"ois-7180-ip"},"namespace":"ois-7180-ip","name":"schema-registry-846b7c5f79-x789m","reconcileID":"380c5c63-8c34-4ca8-ac5f-70225f469843","status":"Failed"}
{"level":"info","ts":"2026-08-21T13:37:26.424Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"request-based-bid-unavailability-v2-584d7499c8-k6hvg","namespace":"for-grogu-fabian"},"namespace":"for-grogu-fabian","name":"request-based-bid-unavailability-v2-584d7499c8-k6hvg","reconcileID":"6a14a953-20b1-4405-afd3-87ae406d26ca","status":"Failed"}
{"level":"info","ts":"2026-08-21T13:37:26.443Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"luma-client-extended-sessions-7cb58f8d66-vlsxm","namespace":"fops-quality-engineering-reviewer"},"namespace":"fops-quality-engineering-reviewer","name":"luma-client-extended-sessions-7cb58f8d66-vlsxm","reconcileID":"1734de13-66b5-4ab4-b94a-e54fe1c22a5a","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.531Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"production-actual-generation-59c6b4fd88-bcfb8","namespace":"fifty-for-forecast-features"},"namespace":"fifty-for-forecast-features","name":"production-actual-generation-59c6b4fd88-bcfb8","reconcileID":"10a2ff6f-278d-474f-ae78-d764dca4c75c","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.554Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"mfrr-reserves-backend-74dd4c48d4-dfr2f","namespace":"fiftyweb-sn-kongsberg"},"namespace":"fiftyweb-sn-kongsberg","name":"mfrr-reserves-backend-74dd4c48d4-dfr2f","reconcileID":"4f2e9b95-5bde-4417-a7f8-71a4bb6025ec","status":"InProgress"}
{"level":"info","ts":"2026-08-21T13:37:26.555Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"sn-skagerrak-backend-eu-7f79468c55-ntmj2","namespace":"fifty-hvdc-staging-jayne"},"namespace":"fifty-hvdc-staging-jayne","name":"sn-skagerrak-backend-eu-7f79468c55-ntmj2","reconcileID":"97e68e1c-6a84-4b5a-8f18-be54cca84751","status":"Failed"}
{"level":"info","ts":"2026-08-21T13:37:26.556Z","msg":"requeueing pod in transition","controller":"pod","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"production-actual-generation-74cc96ccdb-5pn46","namespace":"fifty-for-forecast-features"},"namespace":"fifty-for-forecast-features","name":"production-actual-generation-74cc96ccdb-5pn46","reconcileID":"77da205a-b10e-4a41-9f4c-9375f6f5dc3a","status":"InProgress"}
````

In this PR, I propose changing the logging so that it does not log anything by default if a pod is in transition.