### PR TITLE
fix: use std Go JSON decoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	sigs.k8s.io/cli-utils v0.37.2
 	sigs.k8s.io/controller-runtime v0.25.0
-	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2
@@ -102,5 +101,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
+	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 )

--- a/internal/controller/stas/scan_job_controller.go
+++ b/internal/controller/stas/scan_job_controller.go
@@ -2,6 +2,7 @@ package stas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/json"
 
 	stasv1alpha1 "github.com/statnett/image-scanner-operator/api/stas/v1alpha1"
 	"github.com/statnett/image-scanner-operator/internal/config"
@@ -164,7 +164,7 @@ func (r *ScanJobReconciler) reconcileBackOffJob(ctx context.Context, job *batchv
 func (r *ScanJobReconciler) reconcileCompleteJob(ctx context.Context, job *batchv1.Job, log io.Reader, cis *stasv1alpha1.ContainerImageScan) error {
 	var vulnerabilities []stasv1alpha1.Vulnerability
 
-	err := json.NewDecoderCaseSensitivePreserveInts(log).Decode(&vulnerabilities)
+	err := json.NewDecoder(log).Decode(&vulnerabilities)
 	if err != nil {
 		return newContainerImageStatusPatch(cis).
 			withCondition(


### PR DESCRIPTION
When reviewing https://github.com/statnett/image-scanner-operator/pull/1855, I wondered why we need to depend on a module without releases for features that Go provides out of the box. I took a look at the code, and I think this simplification should be safe and avoid dumb PRs from Renovate.